### PR TITLE
More usable props.

### DIFF
--- a/Patches/VFE_Usable_Props.xml
+++ b/Patches/VFE_Usable_Props.xml
@@ -1913,23 +1913,6 @@
                                 <building Inherit="false">
                                     <preventDeteriorationOnTop>true</preventDeteriorationOnTop>
                                     <ignoreStoredThingsBeauty>false</ignoreStoredThingsBeauty>
-                                    <fixedStorageSettings>
-                                        <filter>
-                                            <categories>
-                                                <li>ResourcesRaw</li>
-                                                <li>Textiles</li>
-                                                <li>MortarShells</li>
-                                                <li>Medicine</li>
-                                            </categories>
-                                            <thingDefs>
-                                                <li>ComponentIndustrial</li>
-                                                <li>ComponentSpacer</li>
-                                            </thingDefs>
-                                            <disallowedCategories>
-                                                <li>PlantMatter</li>
-                                            </disallowedCategories>
-                                        </filter>
-                                    </fixedStorageSettings>
                                 </building>
                                 <comps>
                                  <li Class="LWM.DeepStorage.Properties" >

--- a/Patches/VFE_Usable_Props.xml
+++ b/Patches/VFE_Usable_Props.xml
@@ -2167,4 +2167,8 @@
         </match>
     </Operation>
 
+<<<<<<< Updated upstream
 </Patch>
+=======
+</Patch>
+>>>>>>> Stashed changes

--- a/Patches/VFE_Usable_Props.xml
+++ b/Patches/VFE_Usable_Props.xml
@@ -1,5 +1,5 @@
 <Patch>
-    <!--This file will contain all patches that alter Vanilla Furniture Expanded - Props and Decor. Requires LWM's Deep Storage for most changes. Since this is a large overhaul of one specific mod, I deemed it worthy to have it's own file.-->
+    <!--This file will contain all patches that alter Vanilla Furniture Expanded - Props and Decor. Requires LWM's Deep Storage for most changes. Dropped individual mod item storage support, now storage items are able to store everything but size limits still apply, roleplay as you wish.-->
 
     <!--==========
     Vanilla Furniture Expanded - Props and Decor {LWM's Deep Storage, Dubs Bad Hygiene, Fertile Fields [1.1], Rimatomics, Rimefeller, [D] Thermodynamics - Hot Meals, Vanilla Factions Expanded - Medieval}
@@ -16,6 +16,339 @@
             <match Class="PatchOperationSequence">
                 <success>Always</success>
                 <operations>
+                    <!--Barrels-->
+                    <li Class="PatchOperationRemove">
+                        <xpath>/Defs/ThingDef[defName="VFEPD_BarrelGreen" or defName="VFEPD_BarrelGrey" or defName="VFEPD_BarrelRed" or defName="VFEPD_BarrelYellow" or defName="VFEPD_BarrelBlue"]</xpath>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <ThingDef Name="DZ_VFEPD_BarrelGreen" ParentName="LWM_DeepStorage">
+                                <defName>DZ_VFEPD_BarrelGreen</defName>
+                                <label>green barrel</label>
+                                <description>A green metal barrel used for secure mass storage.</description>
+                                <graphicData>
+                                    <texPath>Things/Building/IndustrialProps/Barrel/Barrel</texPath>
+                                    <graphicClass>Graphic_Multi</graphicClass>
+                                    <shaderType>CutoutComplex</shaderType>
+                                    <drawSize>(1,1)</drawSize>
+                                    <shadowData>
+                                        <volume>(0.55, 0.30, 0.40)</volume>
+                                    </shadowData>
+                                    <color>(117,169,119)</color>
+                                </graphicData>
+                                <altitudeLayer>Building</altitudeLayer>
+                                <passability>PassThroughOnly</passability>
+                                <fillPercent>0.2</fillPercent>
+                                <soundImpactDefault>BulletImpact_Metal</soundImpactDefault>
+                                <repairEffect>ConstructMetal</repairEffect>
+                                <statBases>
+                                    <MaxHitPoints>75</MaxHitPoints>
+                                    <WorkToBuild>100</WorkToBuild>
+                                    <Mass>10</Mass>
+                                    <Flammability>0</Flammability>
+                                </statBases>
+                                <size>(1,1)</size>
+                                <costList>
+                                    <Steel>15</Steel>
+                                </costList>
+                                <uiIconScale>1</uiIconScale>
+                                <designatorDropdown>IndustrialProps</designatorDropdown>
+                                <comps>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>3</maxNumberStacks>
+                                        <minTimeStoringTakes>50</minTimeStoringTakes>
+                                        <showContents>false</showContents>
+                                        <overlayType>None</overlayType>
+                                    </li>
+                                </comps>
+                                <researchPrerequisites>
+                                    <li>IndustrialProps</li>
+                                </researchPrerequisites>
+                            </ThingDef>
+
+                            <ThingDef ParentName="DZ_VFEPD_BarrelGreen">
+                                <defName>DZ_VFEPD_BarrelGrey</defName>
+                                <label>grey barrel</label>
+                                <description>A grey metal barrel used for secure mass storage.</description>
+                                <graphicData>
+                                    <color>(123,123,123)</color>
+                                </graphicData>
+                            </ThingDef>
+
+                            <ThingDef ParentName="DZ_VFEPD_BarrelGreen">
+                                <defName>DZ_VFEPD_BarrelRed</defName>
+                                <label>red barrel</label>
+                                <description>A red metal barrel used for secure mass storage.</description>
+                                <graphicData>
+                                    <color>(168,124,120)</color>
+                                </graphicData>
+                            </ThingDef>
+
+                            <ThingDef ParentName="DZ_VFEPD_BarrelGreen">
+                                <defName>DZ_VFEPD_BarrelYellow</defName>
+                                <label>yellow barrel</label>
+                                <description>A yellow metal barrel used for secure mass storage.</description>
+                                <graphicData>
+                                    <color>(221,181,124)</color>
+                                </graphicData>
+                            </ThingDef>
+
+                            <ThingDef ParentName="DZ_VFEPD_BarrelGreen">
+                                <defName>DZ_VFEPD_BarrelBlue</defName>
+                                <label>blue barrel</label>
+                                <description>A blue metal barrel used for secure mass storage.</description>
+                                <graphicData>
+                                    <color>(127,138,167)</color>
+                                </graphicData>
+                            </ThingDef>
+                        </value>
+                    </li>
+                    <!--Bookshelves-->
+                    <li Class="PatchOperationRemove">
+                        <xpath>/Defs/ThingDef[defName="VFEPD_WoodenBookshelf" or defName="VFEPD_SilverBookshelf" or defName="VFEPD_PlasteelBookshelf" or defName="VFEPD_SteelBookshelf"]</xpath>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <ThingDef ParentName="LWM_DeepStorage">
+                                <defName>DZ_VFEPD_Bookshelf</defName>
+                                <label>bookshelf</label>
+                                <description>A bookshelf containing a variety of unreadable tomes and publications.</description>
+                                <graphicData>
+                                    <texPath>Things/Building/FurnitureProps/Bookshelf/Bookshelf</texPath>
+                                    <graphicClass>Graphic_Multi</graphicClass>
+                                    <shaderType>CutoutComplex</shaderType>
+                                    <drawSize>(3.55,3.45)</drawSize>
+                                    <shadowData>
+                                        <volume>(0.30, 0.30, 0.40)</volume>
+                                    </shadowData>
+                                    <!--<color>(133,97,67)</color>-->
+                                </graphicData>
+                                <tickerType>Normal</tickerType>
+                                <researchPrerequisites>
+                                    <li>MedievalProps</li>
+                                </researchPrerequisites>
+                                <altitudeLayer>Building</altitudeLayer>
+                                <defaultPlacingRot>South</defaultPlacingRot>
+                                <castEdgeShadows>False</castEdgeShadows>
+                                <blockWind>true</blockWind>
+                                <passability>PassThroughOnly</passability>
+                                <fillPercent>0.5</fillPercent>
+                                <soundImpactDefault>BulletImpact_Metal</soundImpactDefault>
+                                <repairEffect>ConstructMetal</repairEffect>
+                                <statBases>
+                                    <MaxHitPoints>20</MaxHitPoints>
+                                    <WorkToBuild>100</WorkToBuild>
+                                    <Mass>6</Mass>
+                                    <Flammability>0.2</Flammability>
+                                </statBases>
+                                <size>(2,1)</size>
+                                <!--<designationCategory>PropsandDecor</designationCategory>-->
+                                <uiIconScale>1</uiIconScale>
+                                <!--<designatorDropdown>FurnitureProps</designatorDropdown>-->
+                                <building>
+                                    <isInert>true</isInert>
+                                </building>
+                                <costStuffCount>50</costStuffCount>
+                                <stuffCategories>
+                                    <li>Stony</li>
+                                    <li>Metallic</li>
+                                    <li>Woody</li>
+                                </stuffCategories>
+                                <comps>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>50</maxNumberStacks>
+                                        <minTimeStoringTakes>50</minTimeStoringTakes>
+                                        <showContents>false</showContents>
+                                        <overlayType>None</overlayType>
+                                    </li>
+                                </comps>
+                            </ThingDef>
+                        </value>
+                    </li>
+                    <!--Bottle Rack-->
+                    <li Class="PatchOperationRemove">
+                        <xpath>/Defs/ThingDef[defName="VFEPD_WineRack"]</xpath>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <ThingDef Name="DZ_VFEPD_WineRack" ParentName="LWM_DeepStorage">
+                                <defName>DZ_VFEPD_WineRack</defName>
+                                <label>bottle rack</label>
+                                <description>A civilized bottle storage rack.</description>
+                                <graphicData>
+                                    <texPath>Things/Building/KitchenProps/WineRack/WineRack</texPath>
+                                    <graphicClass>Graphic_Multi</graphicClass>
+                                    <drawSize>(2,2)</drawSize>
+                                </graphicData>
+                                <researchPrerequisites>
+                                    <li>KitchenProps</li>
+                                </researchPrerequisites>
+                                <rotatable>true</rotatable>
+                                <altitudeLayer>Building</altitudeLayer>
+                                <defaultPlacingRot>South</defaultPlacingRot>
+                                <passability>PassThroughOnly</passability>
+                                <fillPercent>0.3</fillPercent>
+                                <statBases>
+                                    <MaxHitPoints>50</MaxHitPoints>
+                                    <WorkToBuild>50</WorkToBuild>
+                                    <Mass>15</Mass>
+                                    <Beauty>1</Beauty>
+                                    <Flammability>1</Flammability>
+                                </statBases>
+                                <size>(1,1)</size>
+                                <costList>
+                                    <WoodLog>15</WoodLog>
+                                </costList>
+                                <comps>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>5</maxNumberStacks>
+                                        <minTimeStoringTakes>50</minTimeStoringTakes>
+                                        <showContents>false</showContents>
+                                        <overlayType>None</overlayType>
+                                    </li>
+                                </comps>
+                            </ThingDef>
+                        </value>
+                    </li>
+                    <!--Carboard Boxes-->
+                    <li Class="PatchOperationRemove">
+                        <xpath>/Defs/ThingDef[defName="VFEPD_CardboardBoxLarge" or defName="VFEPD_CardboardBoxSmall" or defName="VFEPD_PalletCardboard"]</xpath>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <DesignatorDropdownGroupDef>
+                                <defName>DZ_Storage_CardboardBoxes</defName>
+                            </DesignatorDropdownGroupDef>
+                        </value>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <ThingDef Name="DZ_VFEPD_CardboardBoxLarge" ParentName="LWM_DeepStorage">
+                                <defName>DZ_VFEPD_CardboardBoxLarge</defName>
+                                <label>large cardboard box</label>
+                                <description>A large cardboard box. It can hold light contents. Cheaper than a wooden box.</description>
+                                <graphicData>
+                                    <texPath>Things/Building/IndustrialProps/CardboardLarge/CardboardLarge</texPath>
+                                    <graphicClass>Graphic_Multi</graphicClass>
+                                    <drawSize>(1,1)</drawSize>
+                                    <shadowData>
+                                        <volume>(0.55, 0.30, 0.40)</volume>
+                                    </shadowData>
+                                </graphicData>
+                                <defaultPlacingRot>South</defaultPlacingRot>
+                                <researchPrerequisites>
+                                    <li>IndustrialProps</li>
+                                </researchPrerequisites>
+                                <altitudeLayer>Building</altitudeLayer>
+                                <passability>PassThroughOnly</passability>
+                                <fillPercent>0.3</fillPercent>
+                                <statBases>
+                                    <MaxHitPoints>10</MaxHitPoints>
+                                    <WorkToBuild>50</WorkToBuild>
+                                    <Mass>1</Mass>
+                                    <Flammability>1</Flammability>
+                                </statBases>
+                                <size>(1,1)</size>
+                                <costList>
+                                    <WoodLog>20</WoodLog>
+                                </costList>
+                                <uiIconScale>1</uiIconScale>
+                                <designatorDropdown>DZ_Storage_CardboardBoxes</designatorDropdown>
+                                <building>
+                                    <ignoreStoredThingsBeauty>true</ignoreStoredThingsBeauty>
+                                    <preventDeteriorationOnTop>true</preventDeteriorationOnTop>
+                                </building>
+                                <comps>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>5</maxNumberStacks>
+                                        <minTimeStoringTakes>20</minTimeStoringTakes>
+                                        <additionalTimeEachStack>20</additionalTimeEachStack>
+                                        <additionalTimeEachDef>30</additionalTimeEachDef>   
+                                        <maxTotalMass>25</maxTotalMass>                                                           <!--Cardboard boxes hold less weight to differ from crates-->
+                                        <showContents>false</showContents>
+                                        <overlayType>None</overlayType>
+                                    </li>
+                                </comps>
+                            </ThingDef>
+
+                            <ThingDef ParentName="DZ_VFEPD_CardboardBoxLarge">
+                                <defName>DZ_VFEPD_CardboardBoxSmall</defName>
+                                <label>small cardboard box</label>
+                                <description>A small cardboard box. It can hold light contents. Cheaper than a wooden box.</description>
+                                <graphicData>
+                                    <texPath>Things/Building/IndustrialProps/CardboardSmall/CardboardSmall</texPath>
+                                    <graphicClass>Graphic_Multi</graphicClass>
+                                    <drawSize>(1,1)</drawSize>
+                                    <shadowData>
+                                        <volume>(0.55, 0.30, 0.40)</volume>
+                                    </shadowData>
+                                </graphicData>
+                                <fillPercent>0.1</fillPercent>
+                                <statBases>
+                                    <MaxHitPoints>10</MaxHitPoints>
+                                    <WorkToBuild>50</WorkToBuild>
+                                    <Mass>1</Mass>
+                                    <Flammability>1</Flammability>
+                                </statBases>
+                                <size>(1,1)</size>
+                                <costList>
+                                    <WoodLog>10</WoodLog>
+                                </costList>
+                                <comps>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>3</maxNumberStacks>
+                                        <minTimeStoringTakes>20</minTimeStoringTakes>
+                                        <additionalTimeEachStack>20</additionalTimeEachStack>
+                                        <additionalTimeEachDef>10</additionalTimeEachDef>   
+                                        <maxTotalMass>15</maxTotalMass>                                                           <!--Easier to use if it only stores the same item-->
+                                        <showContents>false</showContents>
+                                        <overlayType>None</overlayType>
+                                    </li>
+                                </comps>
+                            </ThingDef>
+
+                            <ThingDef ParentName="DZ_VFEPD_CardboardBoxLarge">
+                                <defName>VFEPD_PalletCardboard</defName>
+                                <label>pallet with cardboard boxes</label>
+                                <description>A large pallet with several cardboard boxes.</description>
+                                <graphicData>
+                                    <texPath>Things/Building/IndustrialProps/PalletCardboard</texPath>
+                                    <graphicClass>Graphic_Random</graphicClass>
+                                    <drawSize>(3,3)</drawSize>
+                                    <shadowData>
+                                        <volume>(0.55, 0.30, 0.40)</volume>
+                                    </shadowData>
+                                </graphicData>
+                                <fillPercent>0.4</fillPercent>
+                                <statBases>
+                                    <MaxHitPoints>150</MaxHitPoints>
+                                    <WorkToBuild>300</WorkToBuild>
+                                    <Mass>20</Mass>
+                                    <Flammability>1</Flammability>
+                                </statBases>
+                                <size>(2,2)</size>
+                                <costList>
+                                    <WoodLog>100</WoodLog>
+                                </costList>
+                                <comps>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>5</maxNumberStacks>
+                                        <minTimeStoringTakes>20</minTimeStoringTakes>
+                                        <additionalTimeEachStack>20</additionalTimeEachStack>
+                                        <additionalTimeEachDef>20</additionalTimeEachDef>
+                                        <maxTotalMass>150</maxTotalMass>    
+                                        <showContents>false</showContents>
+                                        <overlayType>None</overlayType>
+                                    </li>
+                                </comps>
+                            </ThingDef>
+                        </value>
+                    </li>
                     <!--Cargo Containers-->
                     <li Class="PatchOperationRemove">
                         <xpath>/Defs/ThingDef[defName="VFEPD_ContainerGreen" or defName="VFEPD_ContainerGrey" or defName="VFEPD_ContainerRed" or defName="VFEPD_ContainerYellow" or defName="VFEPD_ContainerBlue"]</xpath>
@@ -23,10 +356,10 @@
                     <li Class="PatchOperationAdd">
                         <xpath>/Defs</xpath>
                         <value>
-                            <ThingDef Name="DZ_VFEPD_ContainerGreen" ParentName="LWM_Skip">
+                            <ThingDef Name="DZ_VFEPD_ContainerGreen" ParentName="LWM_DeepStorage">
                                 <defName>DZ_VFEPD_ContainerGreen</defName>
                                 <label>green cargo container</label>
-                                <description>A green metal cargo container, similar to a skip. Impassable. Cannot hold roof.</description>
+                                <description>A green metal cargo container, similar to a skip. Passable. Cannot hold roof.</description>
                                 <graphicData>
                                     <texPath>Things/Building/IndustrialProps/ShippingContainer/ShippingContainer</texPath>
                                     <graphicClass>Graphic_Multi</graphicClass>
@@ -36,7 +369,6 @@
                                     </shadowData>
                                     <color>(117,169,119)</color>
                                 </graphicData>
-                                <staticSunShadowHeight Inherit="false" />
                                 <defaultPlacingRot>South</defaultPlacingRot>
                                 <castEdgeShadows>True</castEdgeShadows>
                                 <blockWind>true</blockWind>
@@ -54,8 +386,6 @@
                                 <costList>
                                     <Steel>150</Steel>
                                 </costList>
-                                <costStuffCount Inherit="false" />
-                                <stuffCategories Inherit="false" />
                                 <uiIconScale>1</uiIconScale>
                                 <designatorDropdown>IndustrialPropsContainers</designatorDropdown>
                                 <building>
@@ -111,111 +441,575 @@
                             </ThingDef>
                         </value>
                     </li>
-                    <!--Barrels-->
+                    <!--Concrete Bags. Renamed to storage bags.-->
                     <li Class="PatchOperationRemove">
-                        <xpath>/Defs/ThingDef[defName="VFEPD_BarrelGreen" or defName="VFEPD_BarrelGrey" or defName="VFEPD_BarrelRed" or defName="VFEPD_BarrelYellow" or defName="VFEPD_BarrelBlue"]</xpath>
+                        <xpath>/Defs/ThingDef[defName="VFEPD_ConcreteBags"]</xpath>
                     </li>
                     <li Class="PatchOperationAdd">
                         <xpath>/Defs</xpath>
                         <value>
-                            <ThingDef Name="DZ_VFEPD_BarrelGreen" ParentName="LWM_Skip">
-                                <defName>DZ_VFEPD_BarrelGreen</defName>
-                                <label>green barrel</label>
-                                <description>A green metal barrel used for secure mass storage.</description>
+                            <ThingDef Name="DZ_VFEPD_ConcreteBags" ParentName="LWM_DeepStorage">
+                                <defName>DZ_VFEPD_ConcreteBags</defName>
+                                <label>storage bags</label>
+                                <description>A stack of storage bags. Can hold loose materials. Items stored here will not deteriorate.</description>
                                 <graphicData>
-                                    <texPath>Things/Building/IndustrialProps/Barrel/Barrel</texPath>
-                                    <graphicClass>Graphic_Multi</graphicClass>
-                                    <shaderType>CutoutComplex</shaderType>
+                                    <texPath>Things/Building/IndustrialProps/ConcreteBags/ConcreteBags</texPath>
+                                    <graphicClass>Graphic_Single</graphicClass>
                                     <drawSize>(1,1)</drawSize>
                                     <shadowData>
                                         <volume>(0.55, 0.30, 0.40)</volume>
                                     </shadowData>
-                                    <color>(117,169,119)</color>
                                 </graphicData>
-                                <staticSunShadowHeight Inherit="false" />
+                                <defaultPlacingRot>North</defaultPlacingRot>
+                                <rotatable>false</rotatable>
+                                <researchPrerequisites>
+                                    <li>IndustrialProps</li>
+                                </researchPrerequisites>
                                 <altitudeLayer>Building</altitudeLayer>
                                 <passability>PassThroughOnly</passability>
-                                <fillPercent>0.2</fillPercent>
-                                <soundImpactDefault>BulletImpact_Metal</soundImpactDefault>
-                                <repairEffect>ConstructMetal</repairEffect>
+                                <fillPercent>0.3</fillPercent>
                                 <statBases>
-                                    <MaxHitPoints>75</MaxHitPoints>
-                                    <WorkToBuild>100</WorkToBuild>
-                                    <Mass>10</Mass>
-                                    <Flammability>0</Flammability>
+                                    <MaxHitPoints>20</MaxHitPoints>
+                                    <WorkToBuild>130</WorkToBuild>
+                                    <Mass>5</Mass>
+                                    <Flammability>0.2</Flammability>
                                 </statBases>
                                 <size>(1,1)</size>
                                 <costList>
-                                    <Steel>15</Steel>
+                                    <WoodLog>10</WoodLog>
+                                    <Cloth>60</Cloth>
                                 </costList>
-                                <costStuffCount Inherit="false" />
-                                <stuffCategories Inherit="false" />
                                 <uiIconScale>1</uiIconScale>
-                                <designatorDropdown>IndustrialProps</designatorDropdown>
-                                <building Inherit="false">
+                                <comps>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>8</maxNumberStacks>
+                                        <minTimeStoringTakes>150</minTimeStoringTakes>
+                                        <additionalTimeEachStack>10</additionalTimeEachStack>
+                                        <additionalTimeEachDef>50</additionalTimeEachDef>
+                                        <showContents>false</showContents>
+                                        <overlayType>None</overlayType>
+                                    </li>
+                                </comps>
+                            </ThingDef>
+                        </value>
+                    </li>
+                    <!--Hay Bales-->
+                    <li Class="PatchOperationRemove">
+                        <xpath>/Defs/ThingDef[defName="VFEPD_HayBaleSmall" or defName="VFEPD_HayBaleMedium" or defName="VFEPD_HayBaleLarge"]</xpath>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <DesignatorDropdownGroupDef>
+                                <defName>DZ_Storage_HayBales</defName>
+                            </DesignatorDropdownGroupDef>
+                        </value>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <ThingDef Name="DZ_VFEPD_HayBaleSmall" ParentName="LWM_DeepStorage">
+                                <defName>DZ_VFEPD_HayBaleSmall</defName>
+                                <label>small hay bale</label>
+                                <description>A small block of hay.</description>
+                                <graphicData>
+                                    <texPath>Things/Building/FarmProps/HayBaleSmall/HayBaleSmall</texPath>
+                                    <graphicClass>Graphic_Multi</graphicClass>
+                                    <drawSize>(1,1)</drawSize>
+                                    <shadowData>
+                                        <volume>(0.55, 0.30, 0.40)</volume>
+                                    </shadowData>
+                                </graphicData>
+                                <defaultPlacingRot>South</defaultPlacingRot>
+                                <researchPrerequisites>
+                                    <li>FarmProps</li>
+                                </researchPrerequisites>
+                                <altitudeLayer>Building</altitudeLayer>
+                                <passability>PassThroughOnly</passability>
+                                <fillPercent>0.05</fillPercent>
+                                <statBases>
+                                    <MaxHitPoints>70</MaxHitPoints>
+                                    <WorkToBuild>100</WorkToBuild>
+                                    <Mass>5</Mass>
+                                    <Flammability>1</Flammability>
+                                </statBases>
+                                <size>(1,1)</size>
+                                <costList>
+                                    <Hay>20</Hay>
+                                </costList>
+                                <uiIconScale>1</uiIconScale>
+                                <designatorDropdown>DZ_Storage_HayBales</designatorDropdown>
+                                <comps>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>3</maxNumberStacks>
+                                        <minTimeStoringTakes>100</minTimeStoringTakes>
+                                        <additionalTimeStackSize>8</additionalTimeStackSize>
+                                        <showContents>false</showContents>
+                                        <overlayType>None</overlayType>
+                                    </li>
+                                </comps>
+                            </ThingDef>
+
+                            <ThingDef ParentName="DZ_VFEPD_HayBaleSmall">
+                                <defName>DZ_VFEPD_HayBaleMedium</defName>
+                                <label>medium hay bale</label>
+                                <description>A medium block of hay.</description>
+                                <graphicData>
+                                    <texPath>Things/Building/FarmProps/HayBaleMedium/HayBaleMedium</texPath>
+                                    <graphicClass>Graphic_Multi</graphicClass>
+                                    <drawSize>(1,1)</drawSize>
+                                    <shadowData>
+                                        <volume>(0.55, 0.30, 0.40)</volume>
+                                    </shadowData>
+                                </graphicData>
+                                <fillPercent>0.1</fillPercent>
+                                <statBases>
+                                    <MaxHitPoints>100</MaxHitPoints>
+                                    <WorkToBuild>300</WorkToBuild>
+                                    <Mass>5</Mass>
+                                    <Flammability>1</Flammability>
+                                </statBases>
+                                <costList>
+                                    <Hay>50</Hay>
+                                </costList>
+                                <comps>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>5</maxNumberStacks>
+                                        <minTimeStoringTakes>100</minTimeStoringTakes>
+                                        <additionalTimeStackSize>8</additionalTimeStackSize>
+                                        <showContents>false</showContents>
+                                        <overlayType>None</overlayType>
+                                    </li>
+                                </comps>
+                            </ThingDef>
+
+                            <ThingDef ParentName="DZ_VFEPD_HayBaleSmall">
+                                <defName>DZ_VFEPD_HayBaleLarge</defName>
+                                <label>large hay bale</label>
+                                <description>A large roll of hay.</description>
+                                <graphicData>
+                                    <texPath>Things/Building/FarmProps/HayBaleLarge/HayBaleLarge</texPath>
+                                    <graphicClass>Graphic_Multi</graphicClass>
+                                    <drawSize>(2,2)</drawSize>
+                                    <shadowData>
+                                        <volume>(0.55, 0.30, 0.40)</volume>
+                                    </shadowData>
+                                </graphicData>
+                                <fillPercent>0.3</fillPercent>
+                                <statBases>
+                                    <MaxHitPoints>500</MaxHitPoints>
+                                    <WorkToBuild>1000</WorkToBuild>
+                                    <Mass>250</Mass>
+                                    <Flammability>1</Flammability>
+                                </statBases>
+                                <size>(2,2)</size>
+                                <costList>
+                                    <Hay>250</Hay>
+                                </costList>
+                                <comps>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>3</maxNumberStacks>
+                                        <minTimeStoringTakes>100</minTimeStoringTakes>
+                                        <additionalTimeStackSize>8</additionalTimeStackSize>
+                                        <showContents>false</showContents>
+                                        <overlayType>None</overlayType>
+                                    </li>
+                                </comps>
+                            </ThingDef>
+
+                        </value>
+                    </li>
+                    <!--Lockers-->
+                    <li Class="PatchOperationRemove">
+                        <xpath>/Defs/ThingDef[defName="VFEPD_Lockers"]</xpath>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <ThingDef Name="DZ_VFEPD_Lockers" ParentName="LWM_DeepStorage">
+                                <defName>DZ_VFEPD_Lockers</defName>
+                                <label>lockers</label>
+                                <description>A metal locker unit, can store heavier clothing than a clothing rack.</description>
+                                <graphicData>
+                                    <texPath>Things/Building/IndustrialProps/Lockers/Lockers</texPath>
+                                    <graphicClass>Graphic_Multi</graphicClass>
+                                    <drawSize>(2.5,2.5)</drawSize>
+                                    <shadowData>
+                                        <volume>(0.55, 0.30, 0.40)</volume>
+                                    </shadowData>
+                                </graphicData>
+                                <researchPrerequisites>
+                                    <li>FurnitureProps</li>
+                                </researchPrerequisites>
+                                <altitudeLayer>Building</altitudeLayer>
+                                <defaultPlacingRot>South</defaultPlacingRot>
+                                <castEdgeShadows>False</castEdgeShadows>
+                                <passability>PassThroughOnly</passability>
+                                <blockWind>true</blockWind>
+                                <fillPercent>0.1</fillPercent>
+                                <statBases>
+                                    <MaxHitPoints>50</MaxHitPoints>
+                                    <WorkToBuild>100</WorkToBuild>
+                                    <Mass>10</Mass>
+                                    <Flammability>0.1</Flammability>
+                                </statBases>
+                                <size>(1,1)</size>
+                                <stuffCategories>
+                                    <li>Metallic</li>
+                                </stuffCategories>
+                                <costStuffCount>60</costStuffCount>
+                                <uiIconScale>0.5</uiIconScale>
+                                <building>
+                                    <preventDeteriorationOnTop>true</preventDeteriorationOnTop>
+                                    <ignoreStoredThingsBeauty>true</ignoreStoredThingsBeauty>
+                                </building>
+                                <comps>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>10</maxNumberStacks>
+                                        <minNumberStacks>4</minNumberStacks>
+                                        <minTimeStoringTakes>90</minTimeStoringTakes>
+                                        <additionalTimeEachStack>10</additionalTimeEachStack>
+                                        <showContents>false</showContents>
+                                        <overlayType>None</overlayType>
+                                    </li>
+                                </comps>
+                            </ThingDef>
+                        </value>
+                    </li>
+                    <!--Medieval Armor Stands-->
+                    <li Class="PatchOperationRemove">
+                        <xpath>/Defs/ThingDef[defName="VFEPD_ArmorStandEmpty" or defName="VFEPD_ArmorStandFull"]</xpath>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <DesignatorDropdownGroupDef>
+                                <defName>DZ_Storage_ArmorRacks</defName>
+                            </DesignatorDropdownGroupDef>
+                        </value>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <ThingDef Name="DZ_VFEPD_ArmorStandEmpty" ParentName="LWM_DeepStorage">
+                                <defName>DZ_VFEPD_ArmorStandEmpty</defName>
+                                <label>armor stand empty</label>
+                                <description>An armor stand. It can store apparel. Items stored can deteriorate</description>
+                                <graphicData>
+                                    <texPath>Things/Building/MedievalProps/ArmorStandEmpty/ArmorStandEmpty</texPath>
+                                    <graphicClass>Graphic_Multi</graphicClass>
+                                    <drawSize>(2,2)</drawSize>
+                                </graphicData>
+                                <defaultPlacingRot>South</defaultPlacingRot>
+                                <researchPrerequisites>
+                                    <li>MedievalProps</li>
+                                </researchPrerequisites>
+                                <altitudeLayer>Building</altitudeLayer>
+                                <passability>PassThroughOnly</passability>
+                                <fillPercent>0.3</fillPercent>
+                                <statBases>
+                                    <MaxHitPoints>50</MaxHitPoints>
+                                    <WorkToBuild>100</WorkToBuild>
+                                    <Mass>15</Mass>
+                                    <Beauty>15</Beauty>
+                                    <Flammability>0.7</Flammability>
+                                </statBases>
+                                <size>(1,1)</size>
+                                <costList>
+                                    <WoodLog>40</WoodLog>
+                                </costList>
+                                <uiIconScale>0.7</uiIconScale>
+                                <designatorDropdown>DZ_Storage_ArmorRacks</designatorDropdown>
+                                <building>
+                                    <ignoreStoredThingsBeauty>false</ignoreStoredThingsBeauty>
+                                    <preventDeteriorationOnTop>false</preventDeteriorationOnTop>
+                                </building>
+                                <comps>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>5</maxNumberStacks>
+                                        <minTimeStoringTakes>150</minTimeStoringTakes>
+                                        <additionalTimeEachStack>10</additionalTimeEachStack>
+                                        <maxTotalMass>30</maxTotalMass>
+                                        <showContents>false</showContents>
+                                        <overlayType>None</overlayType>
+                                    </li>
+                                </comps>
+                            </ThingDef>
+
+                            <ThingDef ParentName="DZ_VFEPD_ArmorStandEmpty">
+                                <defName>DZ_VFEPD_ArmorStandFull</defName>
+                                <label>armor stand full</label>
+                                <description>An armor stand. It can store apparel. Items stored here will not be visible but will deteriorate</description>
+                                <graphicData>
+                                    <texPath>Things/Building/MedievalProps/ArmorStandFull/ArmorStandFull</texPath>
+                                    <graphicClass>Graphic_Multi</graphicClass>
+                                    <drawSize>(2,2)</drawSize>
+                                </graphicData>
+                                <building>
+                                    <ignoreStoredThingsBeauty>true</ignoreStoredThingsBeauty>
+                                </building>
+                                <comps>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>5</maxNumberStacks>
+                                        <minTimeStoringTakes>50</minTimeStoringTakes>
+                                        <additionalTimeEachStack>10</additionalTimeEachStack>
+                                        <maxTotalMass>30</maxTotalMass>
+                                        <showContents>false</showContents>
+                                        <overlayType>None</overlayType>
+                                    </li>
+                                </comps>
+                            </ThingDef>
+                        </value>
+                    </li>
+                    <!--Medieval Chests.-->
+                    <li Class="PatchOperationRemove">
+                        <xpath>/Defs/ThingDef[defName="VFEPD_WoodenChest" or defName="VFEPD_WoodenChestLarge"]</xpath>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <DesignatorDropdownGroupDef>
+                                <defName>DZ_Storage_Chests</defName>
+                            </DesignatorDropdownGroupDef>
+                        </value>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <ThingDef Name="DZ_VFEPD_WoodenChest" ParentName="LWM_DeepStorage">
+                                <defName>DZ_VFEPD_WoodenChest</defName>
+                                <label>wooden chest</label>
+                                <description>A medium size wooden chest for storing miscellaneous items. Items stored in this will not deteriorate, even if outside.</description>
+                                <graphicData>
+                                    <texPath>Things/Building/MedievalProps/Chest/Chest</texPath>
+                                    <graphicClass>Graphic_Multi</graphicClass>
+                                    <drawSize>(1,1)</drawSize>
+                                    <shadowData>
+                                        <volume>(0.55, 0.30, 0.40)</volume>
+                                    </shadowData>
+                                </graphicData>
+                                <defaultPlacingRot>South</defaultPlacingRot>
+                                <researchPrerequisites>
+                                    <li>MedievalProps</li>
+                                </researchPrerequisites>
+                                <altitudeLayer>Building</altitudeLayer>
+                                <passability>PassThroughOnly</passability>
+                                <fillPercent>0.3</fillPercent>
+                                <statBases>
+                                    <MaxHitPoints>70</MaxHitPoints>
+                                    <WorkToBuild>150</WorkToBuild>
+                                    <Mass>15</Mass>
+                                    <Flammability>0.7</Flammability>
+                                </statBases>
+                                <size>(1,1)</size>
+                                <costList>
+                                    <WoodLog>40</WoodLog>
+                                </costList>
+                                <uiIconScale>1</uiIconScale>
+                                <designatorDropdown>DZ_Storage_Chests</designatorDropdown>
+                                <building>
                                     <ignoreStoredThingsBeauty>true</ignoreStoredThingsBeauty>
                                     <preventDeteriorationOnTop>true</preventDeteriorationOnTop>
-                                    <fixedStorageSettings>
-                                        <filter>
-                                            <thingDefs>
-                                                <li>Chemfuel</li>
-                                            </thingDefs>
-                                        </filter>
-                                    </fixedStorageSettings>
-                                    <defaultStorageSettings>
-                                        <priority>Important</priority>
-                                        <filter>
-                                        </filter>
-                                    </defaultStorageSettings>
-                                    <isInert>true</isInert>
                                 </building>
                                 <comps>
                                     <li Class="LWM.DeepStorage.Properties">
                                         <maxNumberStacks>3</maxNumberStacks>
                                         <minTimeStoringTakes>50</minTimeStoringTakes>
+                                        <additionalTimeEachStack>75</additionalTimeEachStack>
+                                        <maxTotalMass>45</maxTotalMass>                                        <!--About a medium sized body-->
+                                        <additionalTimeEachDef>20</additionalTimeEachDef>
                                         <showContents>false</showContents>
                                         <overlayType>None</overlayType>
                                     </li>
                                 </comps>
+                            </ThingDef>
+
+                            <ThingDef ParentName="DZ_VFEPD_WoodenChest">
+                                <defName>DZ_VFEPD_WoodenChestLarge</defName>
+                                <label>large wooden box</label>
+                                <description>A large size wooden chest for storing miscellaneous items. Items stored in this will not deteriorate, even if outside.</description>
+                                <graphicData>
+                                    <texPath>Things/Building/MedievalProps/ChestLarge/ChestLarge</texPath>
+                                    <graphicClass>Graphic_Multi</graphicClass>
+                                    <drawSize>(2,2)</drawSize>
+                                    <shadowData>
+                                        <volume>(0.55, 0.30, 0.40)</volume>
+                                    </shadowData>
+                                </graphicData>
+                                <statBases>
+                                    <MaxHitPoints>40</MaxHitPoints>
+                                    <WorkToBuild>100</WorkToBuild>
+                                    <Mass>8</Mass>
+                                    <Flammability>0.7</Flammability>
+                                </statBases>
+                                <size>(2,1)</size>
+                                <costList>
+                                    <WoodLog>60</WoodLog>
+                                </costList>
+                                <comps>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>6</maxNumberStacks>
+                                        <minTimeStoringTakes>50</minTimeStoringTakes>
+                                        <additionalTimeEachStack>75</additionalTimeEachStack>
+                                        <additionalTimeEachDef>20</additionalTimeEachDef>
+                                        <showContents>false</showContents>
+                                        <overlayType>None</overlayType>
+                                    </li>
+                                </comps>
+                            </ThingDef>
+                        </value>
+                    </li>
+                    <!--Medieval Weapon Racks-->
+                    <li Class="PatchOperationRemove">
+                        <xpath>/Defs/ThingDef[defName="VFEPD_WeaponRackEmpty" or defName="VFEPD_WeaponRackSwords" or defName="VFEPD_WeaponRackSpears"]</xpath>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <DesignatorDropdownGroupDef>
+                                <defName>DZ_Storage_WeaponRacks</defName>
+                            </DesignatorDropdownGroupDef>
+                        </value>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <ThingDef Name="DZ_VFEPD_WeaponRackEmpty" ParentName="LWM_DeepStorage">
+                                <defName>DZ_VFEPD_WeaponRackEmpty</defName>
+                                <label>weapon rack empty</label>
+                                <description>A long weapon rack. It can store weapons. Items stored here can deteriorate</description>
+                                <graphicData>
+                                    <texPath>Things/Building/MedievalProps/WeaponRackEmpty/WeaponRackEmpty</texPath>
+                                    <graphicClass>Graphic_Multi</graphicClass>
+                                    <drawSize>(2,2)</drawSize>
+                                    <shadowData>
+                                        <volume>(0.55, 0.30, 0.40)</volume>
+                                    </shadowData>
+                                </graphicData>
+                                <defaultPlacingRot>South</defaultPlacingRot>
+                                <researchPrerequisites>
+                                    <li>MedievalProps</li>
+                                </researchPrerequisites>
+                                <altitudeLayer>Building</altitudeLayer>
+                                <passability>PassThroughOnly</passability>
+                                <fillPercent>0.3</fillPercent>
+                                <statBases>
+                                    <MaxHitPoints>70</MaxHitPoints>
+                                    <WorkToBuild>150</WorkToBuild>
+                                    <Mass>15</Mass>
+                                    <Beauty>15</Beauty>
+                                    <Flammability>0.7</Flammability>
+                                </statBases>
+                                <size>(2,1)</size>
+                                <costList>
+                                    <WoodLog>50</WoodLog>
+                                </costList>
+                                <uiIconScale>1</uiIconScale>
+                                <designatorDropdown>DZ_Storage_WeaponRacks</designatorDropdown>
+                                <building>
+                                    <ignoreStoredThingsBeauty>false</ignoreStoredThingsBeauty>
+                                    <preventDeteriorationOnTop>false</preventDeteriorationOnTop>
+                                </building>
+                                <comps>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>5</maxNumberStacks>
+                                        <minTimeStoringTakes>50</minTimeStoringTakes>
+                                        <additionalTimeEachStack>10</additionalTimeEachStack>
+                                        <showContents>True</showContents>
+                                        <overlayType>None</overlayType>
+                                    </li>
+                                </comps>
+                            </ThingDef>
+
+                            <ThingDef Name="DZ_VFEPD_WeaponRackSwords" ParentName="DZ_VFEPD_WeaponRackEmpty">
+                                <defName>DZ_VFEPD_WeaponRackSwords</defName>
+                                <label>weapon rack swords</label>
+                                <description>A long weapon rack. It can store weapons. Items stored here will not be visible but can deteriorate.</description>
+                                <graphicData>
+                                    <texPath>Things/Building/MedievalProps/WeaponRackSwords/WeaponRackSwords</texPath>
+                                    <graphicClass>Graphic_Multi</graphicClass>
+                                    <drawSize>(2,2)</drawSize>
+                                </graphicData>
+                                <building>
+                                    <ignoreStoredThingsBeauty>true</ignoreStoredThingsBeauty>
+                                </building>
+                                <comps>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>4</maxNumberStacks>
+                                        <minTimeStoringTakes>50</minTimeStoringTakes>
+                                        <additionalTimeEachStack>10</additionalTimeEachStack>
+                                        <showContents>false</showContents>
+                                        <overlayType>None</overlayType>
+                                    </li>
+                                </comps>
+                            </ThingDef>
+
+                            <ThingDef ParentName="DZ_VFEPD_WeaponRackSwords">
+                                <defName>DZ_VFEPD_WeaponRackSpears</defName>
+                                <label>weapon rack spears</label>
+                                <graphicData>
+                                    <texPath>Things/Building/MedievalProps/WeaponRackSpears/WeaponRackSpears</texPath>
+                                    <graphicClass>Graphic_Multi</graphicClass>
+                                    <drawSize>(2,2)</drawSize>
+                                    <shadowData>
+                                        <volume>(0.55, 0.30, 0.40)</volume>
+                                    </shadowData>
+                                </graphicData>
+                            </ThingDef>
+                        </value>
+                    </li>
+                    <!--Pallet. Could be made stuffable, but needs a better texture-->
+                    <li Class="PatchOperationRemove">
+                        <xpath>/Defs/ThingDef[defName="VFEPD_Pallet"]</xpath>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <ThingDef Name="DZ_VFEPD_Pallet" ParentName="LWM_DeepStorage">
+                                <defName>DZ_VFEPD_Pallet</defName>
+                                <label>large pallet</label>
+                                <description>A large pallet. Does not protect against the weather.  Sometimes difficult to manage, but useful nonetheless.</description>
+                                <graphicData>
+                                    <texPath>Things/Building/IndustrialProps/Pallet/Pallet</texPath>
+                                    <graphicClass>Graphic_Single</graphicClass>
+                                    <drawSize>(2,2)</drawSize>
+                                    <shadowData>
+                                        <volume>(0.55, 0.30, 0.40)</volume>
+                                    </shadowData>
+                                </graphicData>
+                                <defaultPlacingRot>North</defaultPlacingRot>
+                                <rotatable>False</rotatable>
                                 <researchPrerequisites>
                                     <li>IndustrialProps</li>
                                 </researchPrerequisites>
-                            </ThingDef>
-
-                            <ThingDef ParentName="DZ_VFEPD_BarrelGreen">
-                                <defName>DZ_VFEPD_BarrelGrey</defName>
-                                <label>grey barrel</label>
-                                <description>A grey metal barrel used for secure mass storage.</description>
-                                <graphicData>
-                                    <color>(123,123,123)</color>
-                                </graphicData>
-                            </ThingDef>
-
-                            <ThingDef ParentName="DZ_VFEPD_BarrelGreen">
-                                <defName>DZ_VFEPD_BarrelRed</defName>
-                                <label>red barrel</label>
-                                <description>A red metal barrel used for secure mass storage.</description>
-                                <graphicData>
-                                    <color>(168,124,120)</color>
-                                </graphicData>
-                            </ThingDef>
-
-                            <ThingDef ParentName="DZ_VFEPD_BarrelGreen">
-                                <defName>DZ_VFEPD_BarrelYellow</defName>
-                                <label>yellow barrel</label>
-                                <description>A yellow metal barrel used for secure mass storage.</description>
-                                <graphicData>
-                                    <color>(221,181,124)</color>
-                                </graphicData>
-                            </ThingDef>
-
-                            <ThingDef ParentName="DZ_VFEPD_BarrelGreen">
-                                <defName>DZ_VFEPD_BarrelBlue</defName>
-                                <label>blue barrel</label>
-                                <description>A blue metal barrel used for secure mass storage.</description>
-                                <graphicData>
-                                    <color>(127,138,167)</color>
-                                </graphicData>
+                                <altitudeLayer>Building</altitudeLayer>
+                                <passability>PassThroughOnly</passability>
+                                <fillPercent>0.1</fillPercent>
+                                <statBases>
+                                    <MaxHitPoints>50</MaxHitPoints>
+                                    <WorkToBuild>100</WorkToBuild>
+                                    <Mass>10</Mass>
+                                    <Flammability>0.7</Flammability>
+                                </statBases>
+                                <size>(2,2)</size>
+                                <costList>
+                                    <WoodLog>100</WoodLog>
+                                </costList>
+                                <uiIconScale>1</uiIconScale>
+                                <building>
+                                    <preventDeteriorationOnTop>false</preventDeteriorationOnTop>
+                                    <ignoreStoredThingsBeauty>false</ignoreStoredThingsBeauty>
+                                </building>
+                                <comps>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>4</maxNumberStacks>
+                                        <minTimeStoringTakes>200</minTimeStoringTakes>
+                                        <additionalTimeEachStack>50</additionalTimeEachStack>
+                                        <additionalTimeEachDef>20</additionalTimeEachDef>
+                                        <showContents>true</showContents>
+                                        <overlayType>None</overlayType>
+                                    </li>
+                                </comps>
                             </ThingDef>
                         </value>
                     </li>
@@ -226,7 +1020,7 @@
                     <li Class="PatchOperationAdd">
                         <xpath>/Defs</xpath>
                         <value>
-                            <ThingDef Name="DZ_VFEPD_PalletBarrelGreen" ParentName="LWM_Skip">
+                            <ThingDef Name="DZ_VFEPD_PalletBarrelGreen" ParentName="LWM_DeepStorage">
                                 <defName>DZ_VFEPD_PalletBarrelGreen</defName>
                                 <label>pallet with green barrels</label>
                                 <description>Green metal barrels on a wooden pallet used for secure mass storage.</description>
@@ -241,7 +1035,6 @@
                                     <color>(117,169,119)</color>
                                 </graphicData>
                                 <rotatable>false</rotatable>
-                                <staticSunShadowHeight Inherit="false" />
                                 <defaultPlacingRot>North</defaultPlacingRot>
                                 <altitudeLayer>Building</altitudeLayer>
                                 <passability>PassThroughOnly</passability>
@@ -259,28 +1052,9 @@
                                     <Steel>100</Steel>
                                     <WoodLog>25</WoodLog>
                                 </costList>
-                                <costStuffCount Inherit="false" />
-                                <stuffCategories Inherit="false" />
                                 <uiIconScale>1</uiIconScale>
                                 <designatorDropdown>IndustrialProps</designatorDropdown>
                                 <castEdgeShadows>True</castEdgeShadows>
-                                <building Inherit="false">
-                                    <ignoreStoredThingsBeauty>true</ignoreStoredThingsBeauty>
-                                    <preventDeteriorationOnTop>true</preventDeteriorationOnTop>
-                                    <fixedStorageSettings>
-                                        <filter>
-                                            <thingDefs>
-                                                <li>Chemfuel</li>
-                                            </thingDefs>
-                                        </filter>
-                                    </fixedStorageSettings>
-                                    <defaultStorageSettings>
-                                        <priority>Important</priority>
-                                        <filter>
-                                        </filter>
-                                    </defaultStorageSettings>
-                                    <isInert>true</isInert>
-                                </building>
                                 <comps>
                                     <li Class="LWM.DeepStorage.Properties">
                                         <maxNumberStacks>27</maxNumberStacks>
@@ -328,6 +1102,53 @@
                                 <graphicData>
                                     <color>(127,138,167)</color>
                                 </graphicData>
+                            </ThingDef>
+                        </value>
+                    </li>
+                    <!--Pile of Bricks-->
+                    <li Class="PatchOperationRemove">
+                        <xpath>/Defs/ThingDef[defName="VFEPD_BrickPile"]</xpath>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <ThingDef Name="DZ_VFEPD_BrickPile" ParentName="LWM_DeepStorage">
+                                <defName>DZ_VFEPD_BrickPile</defName>
+                                <label>brick pile</label>
+                                <description>A pile of bricks.</description>
+                                <graphicData>
+                                    <texPath>Things/Building/IndustrialProps/BrickPile</texPath>
+                                    <graphicClass>Graphic_Random</graphicClass>
+                                    <drawSize>(1,1)</drawSize>
+                                    <shadowData>
+                                        <volume>(0.55, 0.30, 0.40)</volume>
+                                    </shadowData>
+                                </graphicData>
+                                <rotatable>false</rotatable>
+                                <altitudeLayer>Building</altitudeLayer>
+                                <passability>PassThroughOnly</passability>
+                                <fillPercent>0.3</fillPercent>
+                                <statBases>
+                                    <MaxHitPoints>200</MaxHitPoints>
+                                    <WorkToBuild>75</WorkToBuild>
+                                    <Mass>25</Mass>
+                                    <Flammability>0</Flammability>
+                                </statBases>
+                                <size>(1,1)</size>
+                                <stuffCategories Inherit="false">
+                                    <li>Stony</li>
+                                </stuffCategories>
+                                <costStuffCount>50</costStuffCount>
+                                <uiIconScale>1</uiIconScale>
+                                <castEdgeShadows>True</castEdgeShadows>
+                                <comps>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>5</maxNumberStacks>
+                                        <minTimeStoringTakes>50</minTimeStoringTakes>
+                                        <showContents>false</showContents>
+                                        <overlayType>None</overlayType>
+                                    </li>
+                                </comps>
                             </ThingDef>
                         </value>
                     </li>
@@ -454,7 +1275,7 @@
                                 </comps>
                             </ThingDef>
 
-                            <ThingDef Name="DZ_VFEPD_SpacerStorage" ParentName="LWM_Skip">
+                            <ThingDef Name="DZ_VFEPD_SpacerStorage" ParentName="LWM_DeepStorage">
                                 <defName>DZ_VFEPD_SpacerStorage</defName>
                                 <label>advanced storage device</label>
                                 <description>A large, multi-chamber advanced storage device.</description>
@@ -466,7 +1287,6 @@
                                 <researchPrerequisites>
                                     <li>SpacerProps</li>
                                 </researchPrerequisites>
-                                <staticSunShadowHeight Inherit="false" />
                                 <fillPercent>0.35</fillPercent>
                                 <castEdgeShadows>True</castEdgeShadows>
                                 <blockWind>true</blockWind>
@@ -485,34 +1305,8 @@
                                     <Plasteel>180</Plasteel>
                                     <Silver>600</Silver>
                                 </costList>
-                                <costStuffCount Inherit="false" />
-                                <stuffCategories Inherit="false" />
                                 <uiIconScale>1</uiIconScale>
                                 <designatorDropdown>SpacerProps</designatorDropdown>
-                                <building>
-                                    <ignoreStoredThingsBeauty>true</ignoreStoredThingsBeauty>
-                                    <preventDeteriorationOnTop>true</preventDeteriorationOnTop>
-                                    <fixedStorageSettings>
-                                        <filter>
-                                            <categories>
-                                                <li>Chunks</li>
-                                                <li>ResourcesRaw</li>
-                                                <li>Manufactured</li>
-                                                <li>Items</li>
-                                                <li>Weapons</li>
-                                                <li>Apparel</li>
-                                            </categories>
-                                            <disallowedCategories>
-                                                <li>PlantMatter</li>
-                                                <li>Drugs</li>
-                                            </disallowedCategories>
-                                        </filter>
-                                    </fixedStorageSettings>
-                                    <defaultStorageSettings>
-                                        <priority>Important</priority>
-                                    </defaultStorageSettings>
-                                    <isInert>true</isInert>
-                                </building>
                                 <comps>
                                     <li Class="LWM.DeepStorage.Properties">
                                         <maxNumberStacks>10</maxNumberStacks>
@@ -525,1165 +1319,25 @@
 
                         </value>
                     </li>
-                    <!--Hay Bales-->
-                    <li Class="PatchOperationRemove">
-                        <xpath>/Defs/ThingDef[defName="VFEPD_HayBaleSmall" or defName="VFEPD_HayBaleMedium" or defName="VFEPD_HayBaleLarge"]</xpath>
-                    </li>
-                    <li Class="PatchOperationAdd">
-                        <xpath>/Defs</xpath>
-                        <value>
-                            <DesignatorDropdownGroupDef>
-                                <defName>DZ_Storage_HayBales</defName>
-                            </DesignatorDropdownGroupDef>
-                        </value>
-                    </li>
-                    <li Class="PatchOperationAdd">
-                        <xpath>/Defs</xpath>
-                        <value>
-                            <ThingDef Name="DZ_VFEPD_HayBaleSmall" ParentName="LWM_HayLoft">
-                                <defName>DZ_VFEPD_HayBaleSmall</defName>
-                                <label>small hay bale</label>
-                                <description>A small block of hay.</description>
-                                <graphicData>
-                                    <texPath>Things/Building/FarmProps/HayBaleSmall/HayBaleSmall</texPath>
-                                    <graphicClass>Graphic_Multi</graphicClass>
-                                    <drawSize>(1,1)</drawSize>
-                                    <shadowData>
-                                        <volume>(0.55, 0.30, 0.40)</volume>
-                                    </shadowData>
-                                </graphicData>
-                                <staticSunShadowHeight Inherit="false" />
-                                <defaultPlacingRot>South</defaultPlacingRot>
-                                <researchPrerequisites>
-                                    <li>FarmProps</li>
-                                </researchPrerequisites>
-                                <altitudeLayer>Building</altitudeLayer>
-                                <passability>PassThroughOnly</passability>
-                                <fillPercent>0.05</fillPercent>
-                                <statBases>
-                                    <MaxHitPoints>70</MaxHitPoints>
-                                    <WorkToBuild>100</WorkToBuild>
-                                    <Mass>5</Mass>
-                                    <Flammability>1</Flammability>
-                                </statBases>
-                                <size>(1,1)</size>
-                                <costList>
-                                    <Hay>20</Hay>
-                                </costList>
-                                <costStuffCount Inherit="false" />
-                                <stuffCategories Inherit="false" />
-                                <uiIconScale>1</uiIconScale>
-                                <designatorDropdown>DZ_Storage_HayBales</designatorDropdown>
-                                <building Inherit="false">
-                                    <preventDeteriorationOnTop>false</preventDeteriorationOnTop>
-                                    <fixedStorageSettings Inherit="false">
-                                        <filter>
-                                            <thingDefs>
-                                                <li>Hay</li>
-                                            </thingDefs>
-                                        </filter>
-                                    </fixedStorageSettings>
-                                    <defaultStorageSettings Inherit="false" />
-                                    <isInert>true</isInert>
-                                </building>
-                                <comps>
-                                    <li Class="LWM.DeepStorage.Properties">
-                                        <maxNumberStacks>3</maxNumberStacks>
-                                        <minTimeStoringTakes>100</minTimeStoringTakes>
-                                        <additionalTimeStackSize>8</additionalTimeStackSize>
-                                        <showContents>false</showContents>
-                                        <overlayType>None</overlayType>
-                                    </li>
-                                </comps>
-                            </ThingDef>
-
-                            <ThingDef ParentName="DZ_VFEPD_HayBaleSmall">
-                                <defName>DZ_VFEPD_HayBaleMedium</defName>
-                                <label>medium hay bale</label>
-                                <description>A medium block of hay.</description>
-                                <graphicData>
-                                    <texPath>Things/Building/FarmProps/HayBaleMedium/HayBaleMedium</texPath>
-                                    <graphicClass>Graphic_Multi</graphicClass>
-                                    <drawSize>(1,1)</drawSize>
-                                    <shadowData>
-                                        <volume>(0.55, 0.30, 0.40)</volume>
-                                    </shadowData>
-                                </graphicData>
-                                <fillPercent>0.1</fillPercent>
-                                <statBases>
-                                    <MaxHitPoints>100</MaxHitPoints>
-                                    <WorkToBuild>300</WorkToBuild>
-                                    <Mass>5</Mass>
-                                    <Flammability>1</Flammability>
-                                </statBases>
-                                <costList>
-                                    <Hay>50</Hay>
-                                </costList>
-                                <comps>
-                                    <li Class="LWM.DeepStorage.Properties">
-                                        <maxNumberStacks>5</maxNumberStacks>
-                                        <minTimeStoringTakes>100</minTimeStoringTakes>
-                                        <additionalTimeStackSize>8</additionalTimeStackSize>
-                                        <showContents>false</showContents>
-                                        <overlayType>None</overlayType>
-                                    </li>
-                                </comps>
-                            </ThingDef>
-
-                            <ThingDef ParentName="DZ_VFEPD_HayBaleSmall">
-                                <defName>DZ_VFEPD_HayBaleLarge</defName>
-                                <label>large hay bale</label>
-                                <description>A large roll of hay.</description>
-                                <graphicData>
-                                    <texPath>Things/Building/FarmProps/HayBaleLarge/HayBaleLarge</texPath>
-                                    <graphicClass>Graphic_Multi</graphicClass>
-                                    <drawSize>(2,2)</drawSize>
-                                    <shadowData>
-                                        <volume>(0.55, 0.30, 0.40)</volume>
-                                    </shadowData>
-                                </graphicData>
-                                <fillPercent>0.3</fillPercent>
-                                <statBases>
-                                    <MaxHitPoints>500</MaxHitPoints>
-                                    <WorkToBuild>1000</WorkToBuild>
-                                    <Mass>250</Mass>
-                                    <Flammability>1</Flammability>
-                                </statBases>
-                                <size>(2,2)</size>
-                                <costList>
-                                    <Hay>250</Hay>
-                                </costList>
-                                <comps>
-                                    <li Class="LWM.DeepStorage.Properties">
-                                        <maxNumberStacks>3</maxNumberStacks>
-                                        <minTimeStoringTakes>100</minTimeStoringTakes>
-                                        <additionalTimeStackSize>8</additionalTimeStackSize>
-                                        <showContents>false</showContents>
-                                        <overlayType>None</overlayType>
-                                    </li>
-                                </comps>
-                            </ThingDef>
-
-                        </value>
-                    </li>
-                    <!--Pile of Bricks-->
-                    <li Class="PatchOperationRemove">
-                        <xpath>/Defs/ThingDef[defName="VFEPD_BrickPile"]</xpath>
-                    </li>
-                    <li Class="PatchOperationAdd">
-                        <xpath>/Defs</xpath>
-                        <value>
-                            <ThingDef Name="DZ_VFEPD_BrickPile" ParentName="LWM_Skip">
-                                <defName>DZ_VFEPD_BrickPile</defName>
-                                <label>brick pile</label>
-                                <description>A pile of bricks.</description>
-                                <graphicData>
-                                    <texPath>Things/Building/IndustrialProps/BrickPile</texPath>
-                                    <graphicClass>Graphic_Random</graphicClass>
-                                    <drawSize>(1,1)</drawSize>
-                                    <shadowData>
-                                        <volume>(0.55, 0.30, 0.40)</volume>
-                                    </shadowData>
-                                </graphicData>
-                                <rotatable>false</rotatable>
-                                <staticSunShadowHeight Inherit="false" />
-                                <altitudeLayer>Building</altitudeLayer>
-                                <passability>PassThroughOnly</passability>
-                                <fillPercent>0.3</fillPercent>
-                                <statBases>
-                                    <MaxHitPoints>200</MaxHitPoints>
-                                    <WorkToBuild>75</WorkToBuild>
-                                    <Mass>25</Mass>
-                                    <Flammability>0</Flammability>
-                                </statBases>
-                                <size>(1,1)</size>
-                                <stuffCategories Inherit="false">
-                                    <li>Stony</li>
-                                </stuffCategories>
-                                <costStuffCount>50</costStuffCount>
-                                <uiIconScale>1</uiIconScale>
-                                <castEdgeShadows>True</castEdgeShadows>
-                                <building Inherit="false">
-                                    <ignoreStoredThingsBeauty>true</ignoreStoredThingsBeauty>
-                                    <preventDeteriorationOnTop>true</preventDeteriorationOnTop>
-                                    <fixedStorageSettings>
-                                        <filter>
-                                            <categories>
-                                                <li>StoneBlocks</li>
-                                            </categories>
-                                            <thingDefs>
-                                                <li>Jade</li>
-                                            </thingDefs>
-                                        </filter>
-                                    </fixedStorageSettings>
-                                    <defaultStorageSettings>
-                                        <priority>Important</priority>
-                                        <filter>
-                                        </filter>
-                                    </defaultStorageSettings>
-                                    <isInert>true</isInert>
-                                </building>
-                                <comps>
-                                    <li Class="LWM.DeepStorage.Properties">
-                                        <maxNumberStacks>5</maxNumberStacks>
-                                        <minTimeStoringTakes>50</minTimeStoringTakes>
-                                        <showContents>false</showContents>
-                                        <overlayType>None</overlayType>
-                                    </li>
-                                </comps>
-                            </ThingDef>
-                        </value>
-                    </li>
-                    <!--Bottle Rack-->
-                    <li Class="PatchOperationRemove">
-                        <xpath>/Defs/ThingDef[defName="VFEPD_WineRack"]</xpath>
-                    </li>
-                    <li Class="PatchOperationAdd">
-                        <xpath>/Defs</xpath>
-                        <value>
-                            <ThingDef Name="DZ_VFEPD_WineRack" ParentName="LWM_Food_Basket">
-                                <defName>DZ_VFEPD_WineRack</defName>
-                                <label>bottle rack</label>
-                                <description>A civilized bottle storage rack.</description>
-                                <graphicData>
-                                    <texPath>Things/Building/KitchenProps/WineRack/WineRack</texPath>
-                                    <graphicClass>Graphic_Multi</graphicClass>
-                                    <drawSize>(2,2)</drawSize>
-                                </graphicData>
-                                <researchPrerequisites>
-                                    <li>KitchenProps</li>
-                                </researchPrerequisites>
-                                <rotatable>true</rotatable>
-                                <altitudeLayer>Building</altitudeLayer>
-                                <defaultPlacingRot>South</defaultPlacingRot>
-                                <passability>PassThroughOnly</passability>
-                                <fillPercent>0.3</fillPercent>
-                                <statBases>
-                                    <MaxHitPoints>50</MaxHitPoints>
-                                    <WorkToBuild>50</WorkToBuild>
-                                    <Mass>15</Mass>
-                                    <Beauty>1</Beauty>
-                                    <Flammability>1</Flammability>
-                                </statBases>
-                                <size>(1,1)</size>
-                                <costList>
-                                    <WoodLog>15</WoodLog>
-                                </costList>
-                                <costStuffCount Inherit="false" />
-                                <stuffCategories Inherit="false" />
-                                <uiIconScale>1</uiIconScale>
-                                <building Inherit="false">
-                                    <ignoreStoredThingsBeauty>true</ignoreStoredThingsBeauty>
-                                    <preventDeteriorationOnTop>true</preventDeteriorationOnTop>
-                                    <fixedStorageSettings>
-                                        <filter>
-                                            <thingDefs>
-                                                <li>Beer</li>
-                                            </thingDefs>
-                                        </filter>
-                                    </fixedStorageSettings>
-                                    <defaultStorageSettings>
-                                        <priority>Important</priority>
-                                        <filter>
-                                        </filter>
-                                    </defaultStorageSettings>
-                                    <isInert>true</isInert>
-                                </building>
-                                <comps>
-                                    <li Class="LWM.DeepStorage.Properties">
-                                        <maxNumberStacks>5</maxNumberStacks>
-                                        <minTimeStoringTakes>50</minTimeStoringTakes>
-                                        <showContents>false</showContents>
-                                        <overlayType>None</overlayType>
-                                    </li>
-                                </comps>
-                            </ThingDef>
-                        </value>
-                    </li>
-                    <!--Wooden Logs-->
-                    <li Class="PatchOperationRemove">
-                        <xpath>/Defs/ThingDef[defName="VFEPD_WoodenLogs" or defName="VFEPD_WoodenLogsLarge"]</xpath>
-                    </li>
-                    <li Class="PatchOperationAdd">
-                        <xpath>/Defs</xpath>
-                        <value>
-                            <DesignatorDropdownGroupDef>
-                                <defName>DZ_Storage_WoodenLogs</defName>
-                            </DesignatorDropdownGroupDef>
-                        </value>
-                    </li>
-                    <li Class="PatchOperationAdd">
-                        <xpath>/Defs</xpath>
-                        <value>
-                            <ThingDef Name="DZ_VFEPD_WoodenLogs" ParentName="LWM_Skip">
-                                <defName>DZ_VFEPD_WoodenLogs</defName>
-                                <label>wooden logs</label>
-                                <description>A small, passable stack of wooden logs.</description>
-                                <graphicData>	
-                                    <texPath>Things/Building/FarmProps/WoodenLogs/WoodenLogs</texPath>
-                                    <graphicClass>Graphic_Multi</graphicClass>
-                                    <drawSize>(1.5,1.5)</drawSize>
-                                    <shadowData>
-                                        <volume>(0.55, 0.30, 0.40)</volume>
-                                    </shadowData>
-                                </graphicData>
-                                <staticSunShadowHeight Inherit="false" />
-                                <defaultPlacingRot>South</defaultPlacingRot>
-                                <researchPrerequisites>
-                                    <li>FarmProps</li>
-                                </researchPrerequisites>
-                                <altitudeLayer>Building</altitudeLayer>
-                                <passability>PassThroughOnly</passability>
-                                <fillPercent>0.4</fillPercent>
-                                <statBases>
-                                    <MaxHitPoints>70</MaxHitPoints>
-                                    <WorkToBuild>100</WorkToBuild>
-                                    <Mass>5</Mass>
-                                    <Flammability>1</Flammability>
-                                </statBases>
-                                <size>(1,1)</size>
-                                <costList>
-                                    <WoodLog>20</WoodLog>
-                                </costList>
-                                <costStuffCount Inherit="false" />
-                                <stuffCategories Inherit="false" />
-                                <uiIconScale>1</uiIconScale>
-                                <designatorDropdown>DZ_Storage_WoodenLogs</designatorDropdown>
-                                <building Inherit="false">
-                                    <ignoreStoredThingsBeauty>true</ignoreStoredThingsBeauty>
-                                    <preventDeteriorationOnTop>true</preventDeteriorationOnTop>
-                                    <fixedStorageSettings Inherit="false">
-                                        <filter>
-                                            <thingDefs>
-                                                <li>WoodLog</li>
-                                            </thingDefs>
-                                        </filter>
-                                    </fixedStorageSettings>
-                                    <defaultStorageSettings>
-                                        <priority>Important</priority>
-                                        <filter>
-                                        </filter>
-                                    </defaultStorageSettings>
-                                    <isInert>true</isInert>
-                                </building>
-                                <comps>
-                                    <li Class="LWM.DeepStorage.Properties">
-                                        <maxNumberStacks>3</maxNumberStacks>
-                                        <minTimeStoringTakes>50</minTimeStoringTakes>
-                                        <additionalTimeStackSize>4</additionalTimeStackSize>
-                                        <showContents>false</showContents>
-                                        <overlayType>SumOfAllItems</overlayType>
-                                    </li>
-                                </comps>
-                            </ThingDef>
-
-                            <ThingDef ParentName="DZ_VFEPD_WoodenLogs">
-                                <defName>DZ_VFEPD_WoodenLogsLarge</defName>
-                                <label>large wooden logs</label>
-                                <description>A large, impassable stack of wooden logs.</description>
-                                <graphicData>	
-                                    <texPath>Things/Building/FarmProps/WoodenLogsLarge/WoodenLogsLarge</texPath>
-                                    <graphicClass>Graphic_Multi</graphicClass>
-                                    <drawSize>(3,3)</drawSize>
-                                    <shadowData>
-                                        <volume>(0.55, 0.30, 0.40)</volume>
-                                    </shadowData>
-                                </graphicData>
-                                <fillPercent>0.1</fillPercent>
-                                <statBases>
-                                    <MaxHitPoints>100</MaxHitPoints>
-                                    <WorkToBuild>300</WorkToBuild>
-                                    <Mass>20</Mass>
-                                    <Flammability>1</Flammability>
-                                </statBases>
-                                <size>(3,1)</size>
-                                <costList>
-                                    <WoodLog>50</WoodLog>
-                                </costList>
-                                <comps>
-                                    <li Class="LWM.DeepStorage.Properties">
-                                        <maxNumberStacks>4</maxNumberStacks>
-                                        <minTimeStoringTakes>100</minTimeStoringTakes>
-                                        <additionalTimeStackSize>4</additionalTimeStackSize>
-                                        <showContents>false</showContents>
-                                        <overlayType>SumOfAllItems</overlayType>
-                                    </li>
-                                </comps>
-                            </ThingDef>
-                        </value>
-                    </li>
-                    <!--Medieval Weapon Racks-->
-                    <li Class="PatchOperationRemove">
-                        <xpath>/Defs/ThingDef[defName="VFEPD_WeaponRackEmpty" or defName="VFEPD_WeaponRackSwords" or defName="VFEPD_WeaponRackSpears"]</xpath>
-                    </li>
-                    <li Class="PatchOperationAdd">
-                        <xpath>/Defs</xpath>
-                        <value>
-                            <DesignatorDropdownGroupDef>
-                                <defName>DZ_Storage_WeaponRacks</defName>
-                            </DesignatorDropdownGroupDef>
-                        </value>
-                    </li>
-                    <li Class="PatchOperationAdd">
-                        <xpath>/Defs</xpath>
-                        <value>
-                            <ThingDef Name="DZ_VFEPD_WeaponRackEmpty" ParentName="LWM_Big_Shelf">
-                                <defName>DZ_VFEPD_WeaponRackEmpty</defName>
-                                <label>weapon rack</label>
-                                <description>A long weapon rack. It can store weapons. Items stored here can deteriorate</description>
-                                <graphicData>	
-                                    <texPath>Things/Building/MedievalProps/WeaponRackEmpty/WeaponRackEmpty</texPath>
-                                    <graphicClass>Graphic_Multi</graphicClass>
-                                    <drawSize>(2,2)</drawSize>
-                                    <shadowData>
-                                        <volume>(0.55, 0.30, 0.40)</volume>
-                                    </shadowData>
-                                </graphicData>
-                                <staticSunShadowHeight Inherit="false" />
-                                <defaultPlacingRot>South</defaultPlacingRot>
-                                <researchPrerequisites>
-                                    <li>MedievalProps</li>
-                                </researchPrerequisites>
-                                <altitudeLayer>Building</altitudeLayer>
-                                <passability>PassThroughOnly</passability>
-                                <fillPercent>0.3</fillPercent>
-                                <statBases>
-                                    <MaxHitPoints>70</MaxHitPoints>
-                                    <WorkToBuild>150</WorkToBuild>
-                                    <Mass>15</Mass>
-                                    <Beauty>15</Beauty>
-                                    <Flammability>0.7</Flammability>
-                                </statBases>
-                                <size>(2,1)</size>
-                                <costList>
-                                    <WoodLog>50</WoodLog>
-                                </costList>
-                                <costStuffCount Inherit="false" />
-                                <stuffCategories Inherit="false" />
-                                <uiIconScale>1</uiIconScale>
-                                <designatorDropdown>DZ_Storage_WeaponRacks</designatorDropdown>
-                                <building Inherit="false">
-                                    <ignoreStoredThingsBeauty>false</ignoreStoredThingsBeauty>
-                                    <preventDeteriorationOnTop>false</preventDeteriorationOnTop>
-                                    <fixedStorageSettings>
-                                        <filter>
-                                            <categories>
-                                                <li>Weapons</li>
-                                            </categories>
-                                        </filter>
-                                    </fixedStorageSettings>
-                                    <defaultStorageSettings>
-                                        <priority>Important</priority>
-                                        <filter>
-                                        </filter>
-                                    </defaultStorageSettings>
-                                    <isInert>true</isInert>
-                                </building>
-                                <comps>
-                                    <li Class="LWM.DeepStorage.Properties">
-                                        <maxNumberStacks>4</maxNumberStacks>
-                                        <minTimeStoringTakes>50</minTimeStoringTakes>
-                                        <additionalTimeEachStack>10</additionalTimeEachStack>
-                                        <maxTotalMass>30</maxTotalMass>
-                                        <showContents>true</showContents>
-                                        <overlayType>SumOfAllItems</overlayType>
-                                    </li>
-                                </comps>
-                            </ThingDef>
-
-                            <ThingDef Name="DZ_VFEPD_WeaponRackSwords" ParentName="DZ_VFEPD_WeaponRackEmpty">
-                                <defName>DZ_VFEPD_WeaponRackSwords</defName>
-                                <label>weapon rack</label>
-                                <description>A long weapon rack. It can store weapons. Items stored here will not be visible but can deteriorate.</description>
-                                <graphicData>
-                                    <texPath>Things/Building/MedievalProps/WeaponRackSwords/WeaponRackSwords</texPath>
-                                    <graphicClass>Graphic_Multi</graphicClass>
-                                    <drawSize>(2,2)</drawSize>
-                                </graphicData>
-                                <building Inherit="true">
-                                    <ignoreStoredThingsBeauty>true</ignoreStoredThingsBeauty>
-                                </building>
-                                <comps>
-                                    <li Class="LWM.DeepStorage.Properties">
-                                        <maxNumberStacks>4</maxNumberStacks>
-                                        <minTimeStoringTakes>50</minTimeStoringTakes>
-                                        <additionalTimeEachStack>10</additionalTimeEachStack>
-                                        <maxTotalMass>30</maxTotalMass>
-                                        <showContents>false</showContents>
-                                        <overlayType>SumOfAllItems</overlayType>
-                                    </li>
-                                </comps>
-                            </ThingDef>
-
-                            <ThingDef ParentName="DZ_VFEPD_WeaponRackSwords">
-                                <defName>DZ_VFEPD_WeaponRackSpearss</defName>
-                                <graphicData>
-                                    <texPath>Things/Building/MedievalProps/WeaponRackSpears/WeaponRackSpears</texPath>
-                                    <graphicClass>Graphic_Multi</graphicClass>
-                                    <drawSize>(2,2)</drawSize>
-                                    <shadowData>
-                                        <volume>(0.55, 0.30, 0.40)</volume>
-                                    </shadowData>
-                                </graphicData>
-                            </ThingDef>
-                        </value>
-                    </li>
-                    <!--Medieval Armor Stands-->
-                    <li Class="PatchOperationRemove">
-                        <xpath>/Defs/ThingDef[defName="VFEPD_ArmorStandEmpty" or defName="VFEPD_ArmorStandFull"]</xpath>
-                    </li>
-                    <li Class="PatchOperationAdd">
-                        <xpath>/Defs</xpath>
-                        <value>
-                            <DesignatorDropdownGroupDef>
-                                <defName>DZ_Storage_ArmorRacks</defName>
-                            </DesignatorDropdownGroupDef>
-                        </value>
-                    </li>
-                    <li Class="PatchOperationAdd">
-                        <xpath>/Defs</xpath>
-                        <value>
-                            <ThingDef Name="DZ_VFEPD_ArmorStandEmpty" ParentName="LWM_Big_Shelf">
-                                <defName>DZ_VFEPD_ArmorStandEmpty</defName>
-                                <label>armor stand</label>
-                                <description>An armor stand. It can store apparel. Items stored can deteriorate</description>
-                                <graphicData>	
-                                    <texPath>Things/Building/MedievalProps/ArmorStandEmpty/ArmorStandEmpty</texPath>
-                                    <graphicClass>Graphic_Multi</graphicClass>
-                                    <drawSize>(2,2)</drawSize>
-                                </graphicData>
-                                <staticSunShadowHeight Inherit="false" />
-                                <defaultPlacingRot>South</defaultPlacingRot>
-                                <researchPrerequisites>
-                                    <li>MedievalProps</li>
-                                </researchPrerequisites>
-                                <altitudeLayer>Building</altitudeLayer>
-                                <passability>PassThroughOnly</passability>
-                                <fillPercent>0.3</fillPercent>
-                                <statBases>
-                                    <MaxHitPoints>50</MaxHitPoints>
-                                    <WorkToBuild>100</WorkToBuild>
-                                    <Mass>15</Mass>
-                                    <Beauty>15</Beauty>
-                                    <Flammability>0.7</Flammability>
-                                </statBases>
-                                <size>(1,1)</size>
-                                <costList>
-                                    <WoodLog>40</WoodLog>
-                                </costList>
-                                <costStuffCount Inherit="false" />
-                                <stuffCategories Inherit="false" />
-                                <uiIconScale>0.7</uiIconScale>
-                                <designatorDropdown>DZ_Storage_ArmorRacks</designatorDropdown>
-                                <building Inherit="false">
-                                    <ignoreStoredThingsBeauty>false</ignoreStoredThingsBeauty>
-                                    <preventDeteriorationOnTop>false</preventDeteriorationOnTop>
-                                    <fixedStorageSettings>
-                                        <filter>
-                                            <categories>
-                                                <li>Apparel</li>
-                                            </categories>
-                                        </filter>
-                                    </fixedStorageSettings>
-                                    <defaultStorageSettings>
-                                        <priority>Important</priority>
-                                        <filter>
-                                        </filter>
-                                    </defaultStorageSettings>
-                                    <isInert>true</isInert>
-                                </building>
-                                <comps>
-                                    <li Class="LWM.DeepStorage.Properties">
-                                        <maxNumberStacks>4</maxNumberStacks>
-                                        <minTimeStoringTakes>150</minTimeStoringTakes>
-                                        <additionalTimeEachStack>10</additionalTimeEachStack>
-                                        <maxTotalMass>30</maxTotalMass>
-                                        <showContents>true</showContents>
-                                        <overlayType>SumOfAllItems</overlayType>
-                                    </li>
-                                </comps>
-                            </ThingDef>
-
-                            <ThingDef ParentName="DZ_VFEPD_ArmorStandEmpty">
-                                <defName>DZ_VFEPD_ArmorStandFull</defName>
-                                <label>armor stand</label>
-                                <description>An armor stand. It can store apparel. Items stored here will not be visible but will deteriorate</description>
-                                <graphicData>	
-                                    <texPath>Things/Building/MedievalProps/ArmorStandFull/ArmorStandFull</texPath>
-                                    <graphicClass>Graphic_Multi</graphicClass>
-                                    <drawSize>(2,2)</drawSize>
-                                </graphicData>
-                                <building Inherit="true">
-                                    <ignoreStoredThingsBeauty>true</ignoreStoredThingsBeauty>
-                                </building>
-                                <comps>
-                                    <li Class="LWM.DeepStorage.Properties">
-                                        <maxNumberStacks>4</maxNumberStacks>
-                                        <minTimeStoringTakes>50</minTimeStoringTakes>
-                                        <additionalTimeEachStack>10</additionalTimeEachStack>
-                                        <maxTotalMass>30</maxTotalMass>
-                                        <showContents>false</showContents>
-                                        <overlayType>SumOfAllItems</overlayType>
-                                    </li>
-                                </comps>
-                            </ThingDef>
-                        </value>
-                    </li>
-                    <!--Medieval Chests.-->
-                    <li Class="PatchOperationRemove">
-                        <xpath>/Defs/ThingDef[defName="VFEPD_WoodenChest" or defName="VFEPD_WoodenChestLarge"]</xpath>
-                    </li>
-                    <li Class="PatchOperationAdd">
-                        <xpath>/Defs</xpath>
-                        <value>
-                            <DesignatorDropdownGroupDef>
-                                <defName>DZ_Storage_Chests</defName>
-                            </DesignatorDropdownGroupDef>
-                        </value>
-                    </li>
-                    <li Class="PatchOperationAdd">
-                        <xpath>/Defs</xpath>
-                        <value>
-                            <ThingDef Name="DZ_VFEPD_WoodenChest" ParentName="LWM_Big_Shelf">
-                                <defName>DZ_VFEPD_WoodenChest</defName>
-                                <label>wooden chest</label>
-                                <description>A medium size wooden chest for storing miscellaneous items. Items stored in this will not deteriorate, even if outside.</description>
-                                <graphicData>	
-                                    <texPath>Things/Building/MedievalProps/Chest/Chest</texPath>
-                                    <graphicClass>Graphic_Multi</graphicClass>
-                                    <drawSize>(1,1)</drawSize>
-                                    <shadowData>
-                                        <volume>(0.55, 0.30, 0.40)</volume>
-                                    </shadowData>
-                                </graphicData>
-                                <staticSunShadowHeight Inherit="false" />
-                                <defaultPlacingRot>South</defaultPlacingRot>
-                                <researchPrerequisites>
-                                    <li>MedievalProps</li>
-                                </researchPrerequisites>
-                                <altitudeLayer>Building</altitudeLayer>
-                                <passability>PassThroughOnly</passability>
-                                <fillPercent>0.3</fillPercent>
-                                <statBases>
-                                    <MaxHitPoints>70</MaxHitPoints>
-                                    <WorkToBuild>150</WorkToBuild>
-                                    <Mass>15</Mass>
-                                    <Flammability>0.7</Flammability>
-                                </statBases>
-                                <size>(1,1)</size>
-                                <costList>
-                                    <WoodLog>40</WoodLog>
-                                </costList>
-                                <costStuffCount Inherit="false" />
-                                <stuffCategories Inherit="false" />
-                                <uiIconScale>1</uiIconScale>
-                                <designatorDropdown>DZ_Storage_Chests</designatorDropdown>
-                                <building Inherit="false">
-                                    <ignoreStoredThingsBeauty>true</ignoreStoredThingsBeauty>
-                                    <preventDeteriorationOnTop>true</preventDeteriorationOnTop>
-                                    <defaultStorageSettings>
-                                        <priority>Important</priority>
-                                        <filter>
-                                        </filter>
-                                    </defaultStorageSettings>
-                                    <isInert>true</isInert>
-                                </building>
-                                <comps>
-                                    <li Class="LWM.DeepStorage.Properties">
-                                        <maxNumberStacks>3</maxNumberStacks>
-                                        <minTimeStoringTakes>50</minTimeStoringTakes>
-                                        <additionalTimeEachStack>75</additionalTimeEachStack>
-                                        <maxTotalMass>45</maxTotalMass><!--About a medium sized body-->
-                                        <additionalTimeEachDef>20</additionalTimeEachDef>
-                                        <showContents>false</showContents>
-                                        <overlayType>SumOfAllItems</overlayType>
-                                    </li>
-                                </comps>
-                            </ThingDef>
-
-                            <ThingDef ParentName="DZ_VFEPD_WoodenChest">
-                                <defName>DZ_VFEPD_WoodenChestLarge</defName>
-                                <label>large wooden box</label>
-                                <description>A large size wooden chest for storing miscellaneous items. Items stored in this will not deteriorate, even if outside.</description>
-                                <graphicData>	
-                                    <texPath>Things/Building/MedievalProps/ChestLarge/ChestLarge</texPath>
-                                    <graphicClass>Graphic_Multi</graphicClass>
-                                    <drawSize>(2,2)</drawSize>
-                                    <shadowData>
-                                        <volume>(0.55, 0.30, 0.40)</volume>
-                                    </shadowData>
-                                </graphicData>
-                                <statBases>
-                                    <MaxHitPoints>40</MaxHitPoints>
-                                    <WorkToBuild>100</WorkToBuild>
-                                    <Mass>8</Mass>
-                                    <Flammability>0.7</Flammability>
-                                </statBases>
-                                <size>(2,1)</size>
-                                <costList>
-                                    <WoodLog>60</WoodLog>
-                                </costList>
-                                <comps>
-                                    <li Class="LWM.DeepStorage.Properties">
-                                        <maxNumberStacks>3</maxNumberStacks>
-                                        <minTimeStoringTakes>50</minTimeStoringTakes>
-                                        <additionalTimeEachStack>75</additionalTimeEachStack>
-                                        <additionalTimeEachDef>20</additionalTimeEachDef>
-                                        <showContents>false</showContents>
-                                        <overlayType>SumOfAllItems</overlayType>
-                                    </li>
-                                </comps>
-                            </ThingDef>
-                        </value>
-                    </li>
-                    <!--Wagon. Because the object is 1x3, it can't show contents because they would be on top of the handle.-->
-                    <li Class="PatchOperationRemove">
-                        <xpath>/Defs/ThingDef[defName="VFEPD_WoodenWagon"]</xpath>
-                    </li>
-                    <li Class="PatchOperationAdd">
-                        <xpath>/Defs</xpath>
-                        <value>
-                            <ThingDef Name="DZ_VFEPD_WoodenWagon" ParentName="LWM_Big_Shelf">
-                                <defName>DZ_VFEPD_WoodenWagon</defName>
-                                <label>wooden wagon</label>
-                                <description>A large stationary wagon. Can hold various things.</description>
-                                <graphicData>	
-                                    <texPath>Things/Building/FarmProps/Wagon/Wagon</texPath>
-                                    <graphicClass>Graphic_Multi</graphicClass>
-                                    <drawSize>(3,3)</drawSize>
-                                    <shadowData>
-                                        <volume>(0.55, 0.30, 0.40)</volume>
-                                    </shadowData>
-                                </graphicData>
-                                <staticSunShadowHeight Inherit="false" />
-                                <defaultPlacingRot>South</defaultPlacingRot>
-                                <researchPrerequisites>
-                                    <li>FarmProps</li>
-                                </researchPrerequisites>
-                                <altitudeLayer>Building</altitudeLayer>
-                                <passability>PassThroughOnly</passability>
-                                <fillPercent>0.5</fillPercent>
-                                <statBases>
-                                    <MaxHitPoints>100</MaxHitPoints>
-                                    <WorkToBuild>200</WorkToBuild>
-                                    <Mass>5</Mass>
-                                    <Beauty>15</Beauty>
-                                    <Flammability>1</Flammability>
-                                </statBases>
-                                <size>(1,3)</size>
-                                <costList>
-                                    <WoodLog>60</WoodLog>
-                                </costList>
-                                <costStuffCount Inherit="false" />
-                                <stuffCategories Inherit="false" />
-                                <uiIconScale>0.9</uiIconScale>
-                                <building Inherit="false">
-                                    <ignoreStoredThingsBeauty>false</ignoreStoredThingsBeauty>
-                                    <preventDeteriorationOnTop>false</preventDeteriorationOnTop>
-                                    <defaultStorageSettings>
-                                        <priority>Important</priority>
-                                        <filter>
-                                        </filter>
-                                    </defaultStorageSettings>
-                                    <isInert>true</isInert>
-                                </building>
-                                <comps>
-                                    <li Class="LWM.DeepStorage.Properties">
-                                        <maxNumberStacks>3</maxNumberStacks>
-                                        <minTimeStoringTakes>150</minTimeStoringTakes>
-                                        <additionalTimeEachStack>50</additionalTimeEachStack>
-                                        <maxTotalMass>90</maxTotalMass>
-                                        <additionalTimeEachDef>20</additionalTimeEachDef>
-                                        <showContents>false</showContents>
-                                        <overlayType>SumOfItemsPerCell</overlayType>
-                                    </li>
-                                </comps>
-                            </ThingDef>
-                        </value>
-                    </li>
-                    <!--Wooden Boxes-->
-                    <li Class="PatchOperationRemove">
-                        <xpath>/Defs/ThingDef[defName="VFEPD_BoxLarge" or defName="VFEPD_BoxSmall" or defName="VFEPD_PalletBoxes"]</xpath>
-                    </li>
-                    <li Class="PatchOperationAdd">
-                        <xpath>/Defs</xpath>
-                        <value>
-                            <DesignatorDropdownGroupDef>
-                                <defName>DZ_Storage_WoodenBoxes</defName>
-                            </DesignatorDropdownGroupDef>
-                        </value>
-                    </li>
-                    <li Class="PatchOperationAdd">
-                        <xpath>/Defs</xpath>
-                        <value>
-                            <ThingDef Name="DZ_VFEPD_BoxLarge" ParentName="LWM_Big_Shelf">
-                                <defName>DZ_VFEPD_BoxLarge</defName>
-                                <label>large wooden box</label>
-                                <description>A large wooden box that can hold various content.</description>
-                                <graphicData>	
-                                    <texPath>Things/Building/IndustrialProps/BoxLarge/BoxLarge</texPath>
-                                    <graphicClass>Graphic_Multi</graphicClass>
-                                    <drawSize>(1,1)</drawSize>
-                                    <shadowData>
-                                        <volume>(0.55, 0.30, 0.40)</volume>
-                                    </shadowData>
-                                </graphicData>
-                                <staticSunShadowHeight Inherit="false" />
-                                <defaultPlacingRot>South</defaultPlacingRot>
-                                <researchPrerequisites>
-                                    <li>IndustrialProps</li>
-                                </researchPrerequisites>
-                                <altitudeLayer>Building</altitudeLayer>
-                                <passability>PassThroughOnly</passability>
-                                <fillPercent>0.3</fillPercent>
-                                <statBases>
-                                    <MaxHitPoints>70</MaxHitPoints>
-                                    <WorkToBuild>150</WorkToBuild>
-                                    <Mass>15</Mass>
-                                    <Flammability>0.7</Flammability>
-                                </statBases>
-                                <size>(1,1)</size>
-                                <costList>
-                                    <WoodLog>40</WoodLog>
-                                </costList>
-                                <costStuffCount Inherit="false" />
-                                <stuffCategories Inherit="false" />
-                                <uiIconScale>1</uiIconScale>
-                                <designatorDropdown>DZ_Storage_WoodenBoxes</designatorDropdown>
-                                <building Inherit="false">
-                                    <ignoreStoredThingsBeauty>true</ignoreStoredThingsBeauty>
-                                    <preventDeteriorationOnTop>true</preventDeteriorationOnTop>
-                                    <defaultStorageSettings>
-                                        <priority>Important</priority>
-                                        <filter>
-                                        </filter>
-                                    </defaultStorageSettings>
-                                    <isInert>true</isInert>
-                                </building>
-                                <comps>
-                                    <li Class="LWM.DeepStorage.Properties">
-                                        <maxNumberStacks>3</maxNumberStacks>
-                                        <minTimeStoringTakes>50</minTimeStoringTakes>
-                                        <additionalTimeEachStack>20</additionalTimeEachStack>
-                                        <maxTotalMass>45</maxTotalMass><!--About a medium sized body-->
-                                        <additionalTimeEachDef>60</additionalTimeEachDef><!--Easier to use if it only stores the same item-->
-                                        <showContents>false</showContents>
-                                        <overlayType>None</overlayType>
-                                    </li>
-                                </comps>
-                            </ThingDef>
-
-                            <ThingDef ParentName="DZ_VFEPD_BoxLarge">
-                                <defName>DZ_VFEPD_BoxSmall</defName>
-                                <label>small wooden box</label>
-                                <description>A small wooden box that can hold various content.</description>
-                                <graphicData>	
-                                    <texPath>Things/Building/IndustrialProps/BoxSmall/BoxSmall</texPath>
-                                    <graphicClass>Graphic_Multi</graphicClass>
-                                    <drawSize>(1,1)</drawSize>
-                                    <shadowData>
-                                        <volume>(0.55, 0.30, 0.40)</volume>
-                                    </shadowData>
-                                </graphicData>
-                                <fillPercent>0.1</fillPercent>
-                                <statBases>
-                                    <MaxHitPoints>40</MaxHitPoints>
-                                    <WorkToBuild>100</WorkToBuild>
-                                    <Mass>8</Mass>
-                                    <Flammability>0.7</Flammability>
-                                </statBases>
-                                <size>(1,1)</size>
-                                <costList>
-                                    <WoodLog>25</WoodLog>
-                                </costList>
-                                <comps>
-                                    <li Class="LWM.DeepStorage.Properties">
-                                        <maxNumberStacks>2</maxNumberStacks>
-                                        <minTimeStoringTakes>50</minTimeStoringTakes>
-                                        <additionalTimeEachStack>20</additionalTimeEachStack>
-                                        <maxTotalMass>20</maxTotalMass><!--About a small sized body-->
-                                        <additionalTimeEachDef>60</additionalTimeEachDef><!--Easier to use if it only stores the same item-->
-                                        <showContents>false</showContents>
-                                        <overlayType>None</overlayType>
-                                    </li>
-                                </comps>
-                            </ThingDef>
-
-                            <ThingDef ParentName="DZ_VFEPD_BoxLarge">
-                                <defName>DZ_VFEPD_PalletBoxes</defName>
-                                <label>pallet with wooden boxes</label>
-                                <description>A large pallet with several wooden boxes.</description>
-                                <graphicData>	
-                                    <texPath>Things/Building/IndustrialProps/PalletBoxes</texPath>
-                                    <graphicClass>Graphic_Random</graphicClass>
-                                    <drawSize>(3,3)</drawSize>
-                                    <shadowData>
-                                        <volume>(0.55, 0.30, 0.40)</volume>
-                                    </shadowData>
-                                </graphicData>
-                                <fillPercent>0.4</fillPercent>
-                                <statBases>
-                                    <MaxHitPoints>150</MaxHitPoints>
-                                    <WorkToBuild>400</WorkToBuild>
-                                    <Mass>50</Mass>
-                                    <Flammability>0.7</Flammability>
-                                </statBases>
-                                <size>(2,2)</size>
-                                <costList>
-                                    <WoodLog>150</WoodLog>
-                                </costList>
-                                <comps>
-                                    <li Class="LWM.DeepStorage.Properties">
-                                        <maxNumberStacks>4</maxNumberStacks>
-                                        <minTimeStoringTakes>20</minTimeStoringTakes>
-                                        <additionalTimeEachStack>20</additionalTimeEachStack>
-                                        <maxMassOfStoredItem>50</maxMassOfStoredItem><!--About a medium sized body-->
-                                        <maxTotalMass>250</maxTotalMass>
-                                        <additionalTimeEachDef>20</additionalTimeEachDef>
-                                        <showContents>false</showContents>
-                                        <overlayType>None</overlayType>
-                                    </li>
-                                </comps>
-                            </ThingDef>
-                        </value>
-                    </li>
-                    <!--Carboard boxes. They will work mostly for small items. Basically a cheaper food basket-->
-                    <li Class="PatchOperationRemove">
-                        <xpath>/Defs/ThingDef[defName="VFEPD_CardboardBoxLarge" or defName="VFEPD_CardboardBoxSmall" or defName="VFEPD_PalletCardboard"]</xpath>
-                    </li>
-                    <li Class="PatchOperationAdd">
-                        <xpath>/Defs</xpath>
-                        <value>
-                            <DesignatorDropdownGroupDef>
-                                <defName>DZ_Storage_CardboardBoxes</defName>
-                            </DesignatorDropdownGroupDef>
-                        </value>
-                    </li>
-                    <li Class="PatchOperationAdd">
-                        <xpath>/Defs</xpath>
-                        <value>
-                            <ThingDef Name="DZ_VFEPD_CardboardBoxLarge" ParentName="LWM_Big_Shelf">
-                                <defName>DZ_VFEPD_CardboardBoxLarge</defName>
-                                <label>large cardboard box</label>
-                                <description>A large cardboard box. It can hold light contents. Cheaper than a wooden box.</description>
-                                <graphicData>	
-                                    <texPath>Things/Building/IndustrialProps/CardboardLarge/CardboardLarge</texPath>
-                                    <graphicClass>Graphic_Multi</graphicClass>
-                                    <drawSize>(1,1)</drawSize>
-                                    <shadowData>
-                                        <volume>(0.55, 0.30, 0.40)</volume>
-                                    </shadowData>
-                                </graphicData>
-                                <staticSunShadowHeight Inherit="false" />
-                                <defaultPlacingRot>South</defaultPlacingRot>
-                                <researchPrerequisites>
-                                    <li>IndustrialProps</li>
-                                </researchPrerequisites>
-                                <altitudeLayer>Building</altitudeLayer>
-                                <passability>PassThroughOnly</passability>
-                                <fillPercent>0.3</fillPercent>
-                                <statBases>
-                                    <MaxHitPoints>10</MaxHitPoints>
-                                    <WorkToBuild>50</WorkToBuild>
-                                    <Mass>1</Mass>
-                                    <Flammability>1</Flammability>
-                                </statBases>
-                                <size>(1,1)</size>
-                                <costList>
-                                    <WoodLog>20</WoodLog>
-                                </costList>
-                                <costStuffCount Inherit="false" />
-                                <stuffCategories Inherit="false" />
-                                <uiIconScale>1</uiIconScale>
-                                <designatorDropdown>DZ_Storage_CardboardBoxes</designatorDropdown>
-                                <building Inherit="false">
-                                    <ignoreStoredThingsBeauty>true</ignoreStoredThingsBeauty>
-                                    <preventDeteriorationOnTop>true</preventDeteriorationOnTop>
-                                    <fixedStorageSettings>
-                                        <priority>Important</priority>
-                                        <filter>
-                                            <categories>
-                                                <li>FoodRaw</li>
-                                                <li>PlantMatter</li>
-                                                <li>Drugs</li>
-                                                <li>Medicine</li>
-                                            </categories>
-                                        </filter>
-                                    </fixedStorageSettings>
-                                    <isInert>true</isInert>
-                                </building>
-                                <comps>
-                                    <li Class="LWM.DeepStorage.Properties">
-                                        <maxNumberStacks>4</maxNumberStacks>
-                                        <minTimeStoringTakes>20</minTimeStoringTakes>
-                                        <additionalTimeEachStack>20</additionalTimeEachStack>
-                                        <additionalTimeEachDef>30</additionalTimeEachDef><!--Easier to use if it only stores the same item-->
-                                        <showContents>false</showContents>
-                                        <overlayType>None</overlayType>
-                                    </li>
-                                </comps>
-                            </ThingDef>
-
-                            <ThingDef ParentName="DZ_VFEPD_CardboardBoxLarge">
-                                <defName>DZ_VFEPD_CardboardBoxSmall</defName>
-                                <label>small cardboard box</label>
-                                <description>A small cardboard box. It can hold light contents. Cheaper than a wooden box.</description>
-                                <graphicData>	
-                                    <texPath>Things/Building/IndustrialProps/CardboardSmall/CardboardSmall</texPath>
-                                    <graphicClass>Graphic_Multi</graphicClass>
-                                    <drawSize>(1,1)</drawSize>
-                                    <shadowData>
-                                        <volume>(0.55, 0.30, 0.40)</volume>
-                                    </shadowData>
-                                </graphicData>
-                                <fillPercent>0.1</fillPercent>
-                                <statBases>
-                                    <MaxHitPoints>10</MaxHitPoints>
-                                    <WorkToBuild>50</WorkToBuild>
-                                    <Mass>1</Mass>
-                                    <Flammability>1</Flammability>
-                                </statBases>
-                                <size>(1,1)</size>
-                                <costList>
-                                    <WoodLog>10</WoodLog>
-                                </costList>
-                                <comps>
-                                    <li Class="LWM.DeepStorage.Properties">
-                                        <maxNumberStacks>3</maxNumberStacks>
-                                        <minTimeStoringTakes>20</minTimeStoringTakes>
-                                        <additionalTimeEachStack>20</additionalTimeEachStack>
-                                        <additionalTimeEachDef>10</additionalTimeEachDef><!--Easier to use if it only stores the same item-->
-                                        <showContents>false</showContents>
-                                        <overlayType>None</overlayType>
-                                    </li>
-                                </comps>
-                            </ThingDef>
-
-                            <ThingDef ParentName="DZ_VFEPD_CardboardBoxLarge">
-                                <defName>VFEPD_PalletCardboard</defName>
-                                <label>pallet with cardboard boxes</label>
-                                <description>A large pallet with several cardboard boxes.</description>
-                                <graphicData>	
-                                    <texPath>Things/Building/IndustrialProps/PalletCardboard</texPath>
-                                    <graphicClass>Graphic_Random</graphicClass>
-                                    <drawSize>(3,3)</drawSize>
-                                    <shadowData>
-                                        <volume>(0.55, 0.30, 0.40)</volume>
-                                    </shadowData>
-                                </graphicData>
-                                <fillPercent>0.4</fillPercent>
-                                <statBases>
-                                    <MaxHitPoints>150</MaxHitPoints>
-                                    <WorkToBuild>300</WorkToBuild>
-                                    <Mass>20</Mass>
-                                    <Flammability>1</Flammability>
-                                </statBases>
-                                <size>(2,2)</size>
-                                <costList>
-                                    <WoodLog>75</WoodLog>
-                                </costList>
-                                <comps>
-                                    <li Class="LWM.DeepStorage.Properties">
-                                        <maxNumberStacks>5</maxNumberStacks>
-                                        <minTimeStoringTakes>20</minTimeStoringTakes>
-                                        <additionalTimeEachStack>20</additionalTimeEachStack>
-                                        <additionalTimeEachDef>20</additionalTimeEachDef>
-                                        <showContents>false</showContents>
-                                        <overlayType>None</overlayType>
-                                    </li>
-                                </comps>
-                            </ThingDef>
-                        </value>
-                    </li>
-                    <!--Pallet. It will be basically a 2x2 pallet. Could be made stuffable, but needs a better texture-->
-                    <li Class="PatchOperationRemove">
-                        <xpath>/Defs/ThingDef[defName="VFEPD_Pallet"]</xpath>
-                    </li>
-                    <li Class="PatchOperationAdd">
-                        <xpath>/Defs</xpath>
-                        <value>
-                            <ThingDef Name="DZ_VFEPD_Pallet" ParentName="LWM_Pallet">
-                                <defName>DZ_VFEPD_Pallet</defName>
-                                <label>large pallet</label>
-                                <description>A large pallet. Does not protect against the weather.  Sometimes difficult to manage, but useful nonetheless.</description>
-                                <graphicData>	
-                                <texPath>Things/Building/IndustrialProps/Pallet/Pallet</texPath>
-                                <graphicClass>Graphic_Single</graphicClass>
-                                    <drawSize>(2,2)</drawSize>
-                                    <shadowData>
-                                        <volume>(0.55, 0.30, 0.40)</volume>
-                                    </shadowData>
-                                </graphicData>
-                                <staticSunShadowHeight Inherit="false" />
-                                <defaultPlacingRot>South</defaultPlacingRot>
-                                <rotatable>False</rotatable>
-                                <researchPrerequisites>
-                                    <li>IndustrialProps</li>
-                                </researchPrerequisites>
-                                <altitudeLayer>Building</altitudeLayer>
-                                <passability>PassThroughOnly</passability>
-                                <fillPercent>0.1</fillPercent>
-                                <statBases>
-                                    <MaxHitPoints>50</MaxHitPoints>
-                                    <WorkToBuild>100</WorkToBuild>
-                                    <Mass>10</Mass>
-                                    <Flammability>0.7</Flammability>
-                                </statBases>
-                                <size>(2,2)</size>
-                                <costList>
-                                    <WoodLog>100</WoodLog>
-                                </costList>
-                                <costStuffCount Inherit="false" />
-                                <stuffCategories Inherit="false" />
-                                <uiIconScale>1</uiIconScale>
-                                <building Inherit="false">
-                                  <preventDeteriorationOnTop>false</preventDeteriorationOnTop>
-                                  <ignoreStoredThingsBeauty>false</ignoreStoredThingsBeauty>
-                                  <fixedStorageSettings>
-                                    <filter>
-                                      <categories>
-                                        <li>ResourcesRaw</li>
-                                        <li>Textiles</li>
-                                        <li>MortarShells</li>
-                                      </categories>
-                                      <disallowedCategories>
-                                        <li>PlantMatter</li>
-                                      </disallowedCategories>
-                                    </filter>
-                                  </fixedStorageSettings>
-                                </building>
-                                <comps>
-                                 <li Class="LWM.DeepStorage.Properties" >
-                                   <maxNumberStacks>4</maxNumberStacks>
-                                   <minTimeStoringTakes>200</minTimeStoringTakes>
-                                   <additionalTimeEachStack>50</additionalTimeEachStack>
-                                   <additionalTimeEachDef>20</additionalTimeEachDef>
-                                   <overlayType>SumOfAllItems</overlayType>
-                                 </li>
-                                </comps>
-                            </ThingDef>
-                        </value>
-                    </li>
-                    <!--Tall Cabinet. A better food basket. Stuffable instead of fixed materials-->
+                    <!--Tall Cabinet-->
                     <li Class="PatchOperationRemove">
                         <xpath>/Defs/ThingDef[defName="VFEPD_SteelTallCabinet" or defName="VFEPD_PlasteelTallCabinet" or defName="VFEPD_SilverTallCabinet" or defName="VFEPD_WoodenTallCabinet"]</xpath>
                     </li>
                     <li Class="PatchOperationAdd">
                         <xpath>/Defs</xpath>
                         <value>
-                            <ThingDef Name="DZ_VFEPD_TallCabinet" ParentName="LWM_Food_Basket">
+                            <ThingDef Name="DZ_VFEPD_TallCabinet" ParentName="LWM_DeepStorage">
                                 <defName>DZ_VFEPD_TallCabinet</defName>
                                 <label>tall cabbinet</label>
                                 <description>A tall cabinet. Can hold food, drugs and medicine. Better than a food basket.</description>
-                                <graphicData>	
-                                <texPath>Things/Building/FurnitureProps/TallCabinet/TallCabinet</texPath>
-                                <graphicClass>Graphic_Multi</graphicClass>
+                                <graphicData>
+                                    <texPath>Things/Building/FurnitureProps/TallCabinet/TallCabinet</texPath>
+                                    <graphicClass>Graphic_Multi</graphicClass>
                                     <drawSize>(3.55,3.45)</drawSize>
                                     <shadowData>
                                         <volume>(0.30, 0.30, 0.40)</volume>
                                     </shadowData>
                                 </graphicData>
-                                <staticSunShadowHeight Inherit="false" />
                                 <researchPrerequisites>
                                     <li>FurnitureProps</li>
                                 </researchPrerequisites>
@@ -1707,58 +1361,43 @@
                                 </stuffCategories>
                                 <costStuffCount>80</costStuffCount>
                                 <uiIconScale>0.5</uiIconScale>
-                                <building Inherit="false">
+                                <building>
                                     <preventDeteriorationOnTop>true</preventDeteriorationOnTop>
                                     <ignoreStoredThingsBeauty>true</ignoreStoredThingsBeauty>
-                                    <fixedStorageSettings>
-                                        <filter>
-                                            <categories>
-                                                <li>FoodRaw</li>
-                                                <li>PlantMatter</li>
-                                                <li>Drugs</li>
-                                                <li>Medicine</li>
-                                            </categories>
-                                            <thingDefs>
-                                                <li>Pemmican</li>
-                                                <li>Kibble</li>
-                                                <li>Neutroamine</li>
-                                            </thingDefs>
-                                        </filter>
-                                    </fixedStorageSettings>
                                 </building>
                                 <comps>
-                                 <li Class="LWM.DeepStorage.Properties" >
-                                    <maxNumberStacks>6</maxNumberStacks>
-                                    <minTimeStoringTakes>100</minTimeStoringTakes>
-                                    <additionalTimeEachStack>20</additionalTimeEachStack>
-                                    <additionalTimeEachDef>20</additionalTimeEachDef>
-                                    <showContents>false</showContents>
-                                    <overlayType>SumOfItemsPerCell</overlayType>
-                                 </li>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>5</maxNumberStacks>
+                                        <minTimeStoringTakes>100</minTimeStoringTakes>
+                                        <additionalTimeEachStack>20</additionalTimeEachStack>
+                                        <additionalTimeEachDef>20</additionalTimeEachDef>
+                                        <showContents>false</showContents>
+                                        <overlayType>None</overlayType>
+                                    </li>
                                 </comps>
                             </ThingDef>
                         </value>
                     </li>
-                    <!--Lockers, better clothing racks-->
+                    <!--Vending Machines-->
                     <li Class="PatchOperationRemove">
-                        <xpath>/Defs/ThingDef[defName="VFEPD_Lockers"]</xpath>
+                        <xpath>/Defs/ThingDef[defName="VFEPD_SteelVendingMachine" or defName="VFEPD_PlasteelVendingMachine" or defName="VFEPD_SilverVendingMachine" or defName="VFEPD_WoodenVendingMachine"]</xpath>
                     </li>
                     <li Class="PatchOperationAdd">
                         <xpath>/Defs</xpath>
                         <value>
-                            <ThingDef Name="DZ_VFEPD_Lockers" ParentName="LWM_Clothing_Rack">
-                                <defName>DZ_VFEPD_Lockers</defName>
-                                <label>lockers</label>
-                                <description>A metal locker unit, can store heavier clothing than a clothing rack.</description>
-                                <graphicData>	
-                                    <texPath>Things/Building/IndustrialProps/Lockers/Lockers</texPath>
+                            <ThingDef Name="DZ_VFEPD_VendingMachine" ParentName="LWM_DeepStorage">
+                                <defName>DZ_VFEPD_VendingMachine</defName>
+                                <label>vending machine</label>
+                                <description>A vending machine. You can store food and drugs here. Your pawns refuse to pay for using it, though.</description>
+                                <graphicData>
+                                    <texPath>Things/Building/FurnitureProps/VendingMachine/VendingMachine</texPath>
                                     <graphicClass>Graphic_Multi</graphicClass>
-                                    <drawSize>(2.5,2.5)</drawSize>
+                                    <shaderType>CutoutComplex</shaderType>
+                                    <drawSize>(3.5,3.5)</drawSize>
                                     <shadowData>
-                                        <volume>(0.55, 0.30, 0.40)</volume>
+                                        <volume>(0.30, 0.30, 0.40)</volume>
                                     </shadowData>
                                 </graphicData>
-                                <staticSunShadowHeight Inherit="false" />
                                 <researchPrerequisites>
                                     <li>FurnitureProps</li>
                                 </researchPrerequisites>
@@ -1767,10 +1406,10 @@
                                 <castEdgeShadows>False</castEdgeShadows>
                                 <passability>PassThroughOnly</passability>
                                 <blockWind>true</blockWind>
-                                <fillPercent>0.1</fillPercent>
+                                <fillPercent>0.5</fillPercent>
                                 <statBases>
                                     <MaxHitPoints>50</MaxHitPoints>
-                                    <WorkToBuild>100</WorkToBuild>
+                                    <WorkToBuild>120</WorkToBuild>
                                     <Mass>10</Mass>
                                     <Flammability>0.1</Flammability>
                                 </statBases>
@@ -1778,51 +1417,105 @@
                                 <stuffCategories>
                                     <li>Metallic</li>
                                 </stuffCategories>
-                                <costStuffCount>60</costStuffCount>
+                                <costStuffCount>50</costStuffCount>
                                 <uiIconScale>0.5</uiIconScale>
-                                <building Inherit="false">
+                                <building>
                                     <preventDeteriorationOnTop>true</preventDeteriorationOnTop>
                                     <ignoreStoredThingsBeauty>true</ignoreStoredThingsBeauty>
-                                    <fixedStorageSettings>
-                                        <filter>
-                                            <categories>
-                                                <li>Apparel</li>
-                                            </categories>
-                                        </filter>
-                                    </fixedStorageSettings>
                                 </building>
                                 <comps>
-                                 <li Class="LWM.DeepStorage.Properties" >
-                                    <maxNumberStacks>10</maxNumberStacks>
-                                    <minNumberStacks>4</minNumberStacks>
-                                    <maxTotalMass>10</maxTotalMass>
-                                    <minTimeStoringTakes>90</minTimeStoringTakes>
-                                    <additionalTimeEachStack>10</additionalTimeEachStack>
-                                    <showContents>false</showContents>
-                                    <overlayType>CountOfStacksPerCell</overlayType>
-                                </li>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>10</maxNumberStacks>
+                                        <minTimeStoringTakes>25</minTimeStoringTakes>
+                                        <additionalTimeEachStack>5</additionalTimeEachStack>
+                                        <additionalTimeEachDef>2</additionalTimeEachDef>
+                                        <showContents>false</showContents>
+                                        <overlayType>None</overlayType>
+                                    </li>
                                 </comps>
                             </ThingDef>
                         </value>
                     </li>
-                    <!--Warehouses shelfs. They will be a better pallet. Could be made stuffable, but needs better texture.
-                    The one with boxes will be able to store anything. Will be a similar to a tall shelf-->
+                    <!--Wagon. The object is 1x3 and can't show contents because they would be on top of the handle.-->
+                    <li Class="PatchOperationRemove">
+                        <xpath>/Defs/ThingDef[defName="VFEPD_WoodenWagon"]</xpath>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <ThingDef Name="DZ_VFEPD_WoodenWagon" ParentName="LWM_DeepStorage">
+                                <defName>DZ_VFEPD_WoodenWagon</defName>
+                                <label>wooden wagon</label>
+                                <description>A large stationary wagon. Can hold various things.</description>
+                                <graphicData>
+                                    <texPath>Things/Building/FarmProps/Wagon/Wagon</texPath>
+                                    <graphicClass>Graphic_Multi</graphicClass>
+                                    <drawSize>(3,3)</drawSize>
+                                    <shadowData>
+                                        <volume>(0.55, 0.30, 0.40)</volume>
+                                    </shadowData>
+                                </graphicData>
+                                <defaultPlacingRot>South</defaultPlacingRot>
+                                <researchPrerequisites>
+                                    <li>FarmProps</li>
+                                </researchPrerequisites>
+                                <altitudeLayer>Building</altitudeLayer>
+                                <passability>PassThroughOnly</passability>
+                                <fillPercent>0.5</fillPercent>
+                                <statBases>
+                                    <MaxHitPoints>100</MaxHitPoints>
+                                    <WorkToBuild>200</WorkToBuild>
+                                    <Mass>5</Mass>
+                                    <Beauty>15</Beauty>
+                                    <Flammability>1</Flammability>
+                                </statBases>
+                                <size>(1,3)</size>
+                                <costList>
+                                    <WoodLog>60</WoodLog>
+                                </costList>
+                                <uiIconScale>0.9</uiIconScale>
+                                <building>
+                                    <ignoreStoredThingsBeauty>false</ignoreStoredThingsBeauty>
+                                    <preventDeteriorationOnTop>false</preventDeteriorationOnTop>
+                                </building>
+                                <comps>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>5</maxNumberStacks>
+                                        <minTimeStoringTakes>150</minTimeStoringTakes>
+                                        <additionalTimeEachStack>50</additionalTimeEachStack>
+                                        <maxTotalMass>100</maxTotalMass>
+                                        <additionalTimeEachDef>20</additionalTimeEachDef>
+                                        <showContents>false</showContents>
+                                        <overlayType>None</overlayType>
+                                    </li>
+                                </comps>
+                            </ThingDef>
+                        </value>
+                    </li>
+                    <!--Warehouses shelfs. Could be made stuffable, but needs better texture.-->
                     <li Class="PatchOperationRemove">
                         <xpath>/Defs/ThingDef[defName="VFEPD_WarehouseShelfEmpty" or defName="VFEPD_WarehouseShelfBoxes"]</xpath>
                     </li>
                     <li Class="PatchOperationAdd">
                         <xpath>/Defs</xpath>
                         <value>
-                            <ThingDef Name="DZ_VFEPD_WarehouseShelfEmpty" ParentName="LWM_Pallet">
+                            <DesignatorDropdownGroupDef>
+                                <defName>DZ_Storage_WarehouseShelf</defName>
+                            </DesignatorDropdownGroupDef>
+                        </value>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <ThingDef Name="DZ_VFEPD_WarehouseShelfEmpty" ParentName="LWM_DeepStorage">
                                 <defName>DZ_VFEPD_WarehouseShelfEmpty</defName>
                                 <label>warehouse shelf</label>
                                 <description>An impassable warehouse shelf. Can store a lot of things, so long as they are not loose.</description>
-                                <graphicData>	
+                                <graphicData>
                                     <texPath>Things/Building/FurnitureProps/WarehouseShelfEmpty/WarehouseShelfEmpty</texPath>
                                     <graphicClass>Graphic_Multi</graphicClass>
                                     <drawSize>(3,3)</drawSize>
                                 </graphicData>
-                                <staticSunShadowHeight Inherit="false" />
                                 <researchPrerequisites>
                                     <li>IndustrialProps</li>
                                 </researchPrerequisites>
@@ -1842,51 +1535,33 @@
                                 <costList>
                                     <Steel>120</Steel>
                                 </costList>
-                                <costStuffCount Inherit="false" />
-                                <stuffCategories Inherit="false" />
                                 <uiIconScale>1</uiIconScale>
-                                <building Inherit="false">
-                                    <preventDeteriorationOnTop>true</preventDeteriorationOnTop>
+                                <building>
+                                    <preventDeteriorationOnTop>false</preventDeteriorationOnTop>
                                     <ignoreStoredThingsBeauty>false</ignoreStoredThingsBeauty>
-                                    <fixedStorageSettings>
-                                        <filter>
-                                            <categories>
-                                                <li>ResourcesRaw</li>
-                                                <li>Textiles</li>
-                                                <li>MortarShells</li>
-                                                <li>Medicine</li>
-                                            </categories>
-                                            <thingDefs>
-                                                <li>ComponentIndustrial</li>
-                                                <li>ComponentSpacer</li>
-                                            </thingDefs>
-                                            <disallowedCategories>
-                                                <li>PlantMatter</li>
-                                            </disallowedCategories>
-                                        </filter>
-                                    </fixedStorageSettings>
                                 </building>
+                                <designatorDropdown>DZ_Storage_WarehouseShelf</designatorDropdown>
                                 <comps>
-                                 <li Class="LWM.DeepStorage.Properties" >
-                                    <maxNumberStacks>5</maxNumberStacks>
-                                    <minTimeStoringTakes>300</minTimeStoringTakes>
-                                    <additionalTimeEachStack>110</additionalTimeEachStack>
-                                    <additionalTimeEachDef>20</additionalTimeEachDef>
-                                    <overlayType>SumOfItemsPerCell</overlayType>
-                                 </li>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>5</maxNumberStacks>
+                                        <minTimeStoringTakes>300</minTimeStoringTakes>
+                                        <additionalTimeEachStack>110</additionalTimeEachStack>
+                                        <additionalTimeEachDef>20</additionalTimeEachDef>
+                                        <showContents>true</showContents>
+                                        <overlayType>None</overlayType>
+                                    </li>
                                 </comps>
                             </ThingDef>
 
-                            <ThingDef Name="DZ_VFEPD_WarehouseShelfBoxes" ParentName="LWM_VeryBigShelf">
+                            <ThingDef Name="DZ_VFEPD_WarehouseShelfBoxes" ParentName="LWM_DeepStorage">
                                 <defName>DZ_VFEPD_WarehouseShelfBoxes</defName>
-                                <label>warehouse shelf</label>
+                                <label>warehouse shelf with boxes</label>
                                 <description>An impassable warehouse shelf. Can store a lot of things. It can take a while to take and store items from such a tall structure. Items here will not deteriorate, even if outside.</description>
-                                <graphicData>	
+                                <graphicData>
                                     <texPath>Things/Building/FurnitureProps/WarehouseShelfBoxes/WarehouseShelfBoxes</texPath>
                                     <graphicClass>Graphic_Multi</graphicClass>
                                     <drawSize>(3,3)</drawSize>
                                 </graphicData>
-                                <staticSunShadowHeight Inherit="false" />
                                 <researchPrerequisites>
                                     <li>IndustrialProps</li>
                                 </researchPrerequisites>
@@ -1907,121 +1582,55 @@
                                     <Steel>120</Steel>
                                     <WoodLog>20</WoodLog>
                                 </costList>
-                                <costStuffCount Inherit="false" />
-                                <stuffCategories Inherit="false" />
                                 <uiIconScale>1</uiIconScale>
-                                <building Inherit="false">
-                                    <preventDeteriorationOnTop>true</preventDeteriorationOnTop>
-                                    <ignoreStoredThingsBeauty>false</ignoreStoredThingsBeauty>
-                                </building>
-                                <comps>
-                                 <li Class="LWM.DeepStorage.Properties" >
-                                    <maxNumberStacks>5</maxNumberStacks>
-                                    <minTimeStoringTakes>300</minTimeStoringTakes>
-                                    <additionalTimeEachStack>110</additionalTimeEachStack>
-                                    <additionalTimeEachDef>10</additionalTimeEachDef>
-                                    <maxMassOfStoredItem>90</maxMassOfStoredItem>
-                                    <maxTotalMass>320</maxTotalMass>
-                                    <showContents>false</showContents>
-                                    <overlayType>SumOfItemsPerCell</overlayType>
-                                 </li>
-                                </comps>
-                            </ThingDef>
-                        </value>
-                    </li>
-                    <!--Vending machines. Can store meals an drugs. I guess they can make sense for Hospitality's visitors, who can buy stuff from specific areas if allowed.-->
-                    <li Class="PatchOperationRemove">
-                        <xpath>/Defs/ThingDef[defName="VFEPD_SteelVendingMachine" or defName="VFEPD_PlasteelVendingMachine" or defName="VFEPD_SilverVendingMachine" or defName="VFEPD_WoodenVendingMachine"]</xpath>
-                    </li>
-                    <li Class="PatchOperationAdd">
-                        <xpath>/Defs</xpath>
-                        <value>
-                            <ThingDef Name="DZ_VFEPD_VendingMachine" ParentName="LWM_Food_Basket">
-                                <defName>DZ_VFEPD_VendingMachine</defName>
-                                <label>vending machine</label>
-                                <description>A vending machine. You can store food and drugs here. Your pawns refuse to pay for using it, though.</description>
-                                <graphicData>	
-                                    <texPath>Things/Building/FurnitureProps/VendingMachine/VendingMachine</texPath>
-                                    <graphicClass>Graphic_Multi</graphicClass>
-                                    <shaderType>CutoutComplex</shaderType>
-                                    <drawSize>(3.5,3.5)</drawSize>
-                                    <shadowData>
-                                        <volume>(0.30, 0.30, 0.40)</volume>
-                                    </shadowData>
-                                </graphicData>
-                                <staticSunShadowHeight Inherit="false" />
-                                <researchPrerequisites>
-                                    <li>FurnitureProps</li>
-                                </researchPrerequisites>
-                                <altitudeLayer>Building</altitudeLayer>
-                                <defaultPlacingRot>South</defaultPlacingRot>
-                                <castEdgeShadows>False</castEdgeShadows>
-                                <passability>PassThroughOnly</passability>
-                                <blockWind>true</blockWind>
-                                <fillPercent>0.5</fillPercent>
-                                <statBases>
-                                    <MaxHitPoints>50</MaxHitPoints>
-                                    <WorkToBuild>120</WorkToBuild>
-                                    <Mass>10</Mass>
-                                    <Flammability>0.1</Flammability>
-                                </statBases>
-                                <size>(1,1)</size>
-                                <stuffCategories Inherit="false">
-                                    <li>Metallic</li>
-                                </stuffCategories>
-                                <costStuffCount>50</costStuffCount>
-                                <uiIconScale>0.5</uiIconScale>
-                                <building Inherit="false">
+                                <building>
                                     <preventDeteriorationOnTop>true</preventDeteriorationOnTop>
                                     <ignoreStoredThingsBeauty>true</ignoreStoredThingsBeauty>
-                                    <fixedStorageSettings>
-                                        <filter>
-                                            <categories>
-                                                <li>FoodMeals</li>
-                                                <li>Drugs</li>
-                                                <li>Medicine</li>
-                                            </categories>
-                                            <thingDefs>
-                                                <li>Pemmican</li>
-                                            </thingDefs>
-                                        </filter>
-                                    </fixedStorageSettings>
                                 </building>
+                                <designatorDropdown>DZ_Storage_WarehouseShelf</designatorDropdown>
                                 <comps>
-                                 <li Class="LWM.DeepStorage.Properties" >
-                                    <maxNumberStacks>10</maxNumberStacks>
-                                    <minTimeStoringTakes>25</minTimeStoringTakes>
-                                    <additionalTimeEachStack>5</additionalTimeEachStack>
-                                    <additionalTimeEachDef>2</additionalTimeEachDef>
-                                    <showContents>false</showContents>
-                                    <overlayType>SumOfAllItems</overlayType>
-                                 </li>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>5</maxNumberStacks>
+                                        <minTimeStoringTakes>300</minTimeStoringTakes>
+                                        <additionalTimeEachStack>110</additionalTimeEachStack>
+                                        <additionalTimeEachDef>10</additionalTimeEachDef>
+                                        <maxMassOfStoredItem>90</maxMassOfStoredItem>
+                                        <maxTotalMass>320</maxTotalMass>
+                                        <showContents>false</showContents>
+                                        <overlayType>None</overlayType>
+                                    </li>
                                 </comps>
                             </ThingDef>
                         </value>
                     </li>
-                    <!--Concrete bags. Renamed to storage bags. They can hold plant matter in great quantities.-->
+                    <!--Wooden Boxes-->
                     <li Class="PatchOperationRemove">
-                        <xpath>/Defs/ThingDef[defName="VFEPD_ConcreteBags"]</xpath>
+                        <xpath>/Defs/ThingDef[defName="VFEPD_BoxLarge" or defName="VFEPD_BoxSmall" or defName="VFEPD_PalletBoxes"]</xpath>
                     </li>
                     <li Class="PatchOperationAdd">
                         <xpath>/Defs</xpath>
                         <value>
-                            <ThingDef Name="DZ_VFEPD_ConcreteBags" ParentName="LWM_Skip">
-                                <defName>DZ_VFEPD_ConcreteBags</defName>
-                                <label>storage bags</label>
-                                <description>A stack of storage bags. Can hold loose materials. Items stored here will not deteriorate.</description>
-                                <graphicData>	
-                                    <texPath>Things/Building/IndustrialProps/ConcreteBags/ConcreteBags</texPath>
-                                    <graphicClass>Graphic_Single</graphicClass>
+                            <DesignatorDropdownGroupDef>
+                                <defName>DZ_Storage_WoodenBoxes</defName>
+                            </DesignatorDropdownGroupDef>
+                        </value>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <ThingDef Name="DZ_VFEPD_BoxLarge" ParentName="LWM_DeepStorage">
+                                <defName>DZ_VFEPD_BoxLarge</defName>
+                                <label>large wooden box</label>
+                                <description>A large wooden box that can hold various content.</description>
+                                <graphicData>
+                                    <texPath>Things/Building/IndustrialProps/BoxLarge/BoxLarge</texPath>
+                                    <graphicClass>Graphic_Multi</graphicClass>
                                     <drawSize>(1,1)</drawSize>
                                     <shadowData>
                                         <volume>(0.55, 0.30, 0.40)</volume>
                                     </shadowData>
                                 </graphicData>
-                                <staticSunShadowHeight Inherit="false" />
-                                <defaultPlacingRot Inherit="false" />
-                                <rotatable>false</rotatable>
+                                <defaultPlacingRot>South</defaultPlacingRot>
                                 <researchPrerequisites>
                                     <li>IndustrialProps</li>
                                 </researchPrerequisites>
@@ -2029,44 +1638,199 @@
                                 <passability>PassThroughOnly</passability>
                                 <fillPercent>0.3</fillPercent>
                                 <statBases>
-                                    <MaxHitPoints>20</MaxHitPoints>
-                                    <WorkToBuild>130</WorkToBuild>
-                                    <Mass>5</Mass>
-                                    <Flammability>0.2</Flammability>
+                                    <MaxHitPoints>70</MaxHitPoints>
+                                    <WorkToBuild>150</WorkToBuild>
+                                    <Mass>15</Mass>
+                                    <Flammability>0.7</Flammability>
                                 </statBases>
                                 <size>(1,1)</size>
                                 <costList>
-                                    <WoodLog>10</WoodLog>
-                                    <Cloth>60</Cloth>
+                                    <WoodLog>40</WoodLog>
                                 </costList>
-                                <costStuffCount Inherit="false" />
-                                <stuffCategories Inherit="false" />
                                 <uiIconScale>1</uiIconScale>
-                                <building Inherit="false">
-                                    <ignoreStoredThingsBeauty>false</ignoreStoredThingsBeauty>
-                                    <preventDeteriorationOnTop>false</preventDeteriorationOnTop>
-                                    <fixedStorageSettings>
-                                        <filter>
-                                            <categories>
-                                                <li>PlantMatter</li>
-                                            </categories>
-                                        </filter>
-                                    </fixedStorageSettings>
-                                    <defaultStorageSettings>
-                                        <priority>Important</priority>
-                                        <filter>
-                                        </filter>
-                                    </defaultStorageSettings>
-                                    <isInert>true</isInert>
+                                <designatorDropdown>DZ_Storage_WoodenBoxes</designatorDropdown>
+                                <building>
+                                    <ignoreStoredThingsBeauty>true</ignoreStoredThingsBeauty>
+                                    <preventDeteriorationOnTop>true</preventDeteriorationOnTop>
                                 </building>
                                 <comps>
                                     <li Class="LWM.DeepStorage.Properties">
-                                        <maxNumberStacks>8</maxNumberStacks>
-                                        <minTimeStoringTakes>150</minTimeStoringTakes>
-                                        <additionalTimeEachStack>10</additionalTimeEachStack>
-                                        <additionalTimeEachDef>50</additionalTimeEachDef>
+                                        <maxNumberStacks>5</maxNumberStacks>
+                                        <minTimeStoringTakes>50</minTimeStoringTakes>
+                                        <additionalTimeEachStack>20</additionalTimeEachStack>
+                                        <maxTotalMass>50</maxTotalMass>                                        <!--About a medium sized body-->
+                                        <additionalTimeEachDef>60</additionalTimeEachDef>                                        <!--Easier to use if it only stores the same item-->
                                         <showContents>false</showContents>
-                                        <overlayType>SumOfItemsPerCell</overlayType>
+                                        <overlayType>None</overlayType>
+                                    </li>
+                                </comps>
+                            </ThingDef>
+
+                            <ThingDef ParentName="DZ_VFEPD_BoxLarge">
+                                <defName>DZ_VFEPD_BoxSmall</defName>
+                                <label>small wooden box</label>
+                                <description>A small wooden box that can hold various content.</description>
+                                <graphicData>
+                                    <texPath>Things/Building/IndustrialProps/BoxSmall/BoxSmall</texPath>
+                                    <graphicClass>Graphic_Multi</graphicClass>
+                                    <drawSize>(1,1)</drawSize>
+                                    <shadowData>
+                                        <volume>(0.55, 0.30, 0.40)</volume>
+                                    </shadowData>
+                                </graphicData>
+                                <fillPercent>0.1</fillPercent>
+                                <statBases>
+                                    <MaxHitPoints>40</MaxHitPoints>
+                                    <WorkToBuild>100</WorkToBuild>
+                                    <Mass>8</Mass>
+                                    <Flammability>0.7</Flammability>
+                                </statBases>
+                                <size>(1,1)</size>
+                                <costList>
+                                    <WoodLog>25</WoodLog>
+                                </costList>
+                                <comps>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>3</maxNumberStacks>
+                                        <minTimeStoringTakes>50</minTimeStoringTakes>
+                                        <additionalTimeEachStack>20</additionalTimeEachStack>
+                                        <maxTotalMass>25</maxTotalMass>                                        <!--About a small sized body-->
+                                        <additionalTimeEachDef>60</additionalTimeEachDef>                                        <!--Easier to use if it only stores the same item-->
+                                        <showContents>false</showContents>
+                                        <overlayType>None</overlayType>
+                                    </li>
+                                </comps>
+                            </ThingDef>
+
+                            <ThingDef ParentName="DZ_VFEPD_BoxLarge">
+                                <defName>DZ_VFEPD_PalletBoxes</defName>
+                                <label>pallet with wooden boxes</label>
+                                <description>A large pallet with several wooden boxes.</description>
+                                <graphicData>
+                                    <texPath>Things/Building/IndustrialProps/PalletBoxes</texPath>
+                                    <graphicClass>Graphic_Random</graphicClass>
+                                    <drawSize>(3,3)</drawSize>
+                                    <shadowData>
+                                        <volume>(0.55, 0.30, 0.40)</volume>
+                                    </shadowData>
+                                </graphicData>
+                                <fillPercent>0.4</fillPercent>
+                                <statBases>
+                                    <MaxHitPoints>150</MaxHitPoints>
+                                    <WorkToBuild>400</WorkToBuild>
+                                    <Mass>50</Mass>
+                                    <Flammability>0.7</Flammability>
+                                </statBases>
+                                <size>(2,2)</size>
+                                <costList>
+                                    <WoodLog>150</WoodLog>
+                                </costList>
+                                <comps>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>5</maxNumberStacks>
+                                        <minTimeStoringTakes>20</minTimeStoringTakes>
+                                        <additionalTimeEachStack>20</additionalTimeEachStack>
+                                        <maxMassOfStoredItem>50</maxMassOfStoredItem>                                        <!--About a medium sized body-->
+                                        <maxTotalMass>250</maxTotalMass>
+                                        <additionalTimeEachDef>20</additionalTimeEachDef>
+                                        <showContents>false</showContents>
+                                        <overlayType>None</overlayType>
+                                    </li>
+                                </comps>
+                            </ThingDef>
+                        </value>
+                    </li>
+                    <!--Wooden Logs-->
+                    <li Class="PatchOperationRemove">
+                        <xpath>/Defs/ThingDef[defName="VFEPD_WoodenLogs" or defName="VFEPD_WoodenLogsLarge"]</xpath>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <DesignatorDropdownGroupDef>
+                                <defName>DZ_Storage_WoodenLogs</defName>
+                            </DesignatorDropdownGroupDef>
+                        </value>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <ThingDef Name="DZ_VFEPD_WoodenLogs" ParentName="LWM_DeepStorage">
+                                <defName>DZ_VFEPD_WoodenLogs</defName>
+                                <label>wooden logs</label>
+                                <description>A small, passable stack of wooden logs.</description>
+                                <graphicData>
+                                    <texPath>Things/Building/FarmProps/WoodenLogs/WoodenLogs</texPath>
+                                    <graphicClass>Graphic_Multi</graphicClass>
+                                    <drawSize>(1.5,1.5)</drawSize>
+                                    <shadowData>
+                                        <volume>(0.55, 0.30, 0.40)</volume>
+                                    </shadowData>
+                                </graphicData>
+                                <defaultPlacingRot>South</defaultPlacingRot>
+                                <researchPrerequisites>
+                                    <li>FarmProps</li>
+                                </researchPrerequisites>
+                                <altitudeLayer>Building</altitudeLayer>
+                                <passability>PassThroughOnly</passability>
+                                <fillPercent>0.4</fillPercent>
+                                <statBases>
+                                    <MaxHitPoints>70</MaxHitPoints>
+                                    <WorkToBuild>100</WorkToBuild>
+                                    <Mass>5</Mass>
+                                    <Flammability>1</Flammability>
+                                </statBases>
+                                <size>(1,1)</size>
+                                <costList>
+                                    <WoodLog>20</WoodLog>
+                                </costList>
+                                <uiIconScale>1</uiIconScale>
+                                <designatorDropdown>DZ_Storage_WoodenLogs</designatorDropdown>
+                                <building>
+                                    <ignoreStoredThingsBeauty>true</ignoreStoredThingsBeauty>
+                                    <preventDeteriorationOnTop>false</preventDeteriorationOnTop>
+                                </building>
+                                <comps>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>5</maxNumberStacks>
+                                        <minTimeStoringTakes>50</minTimeStoringTakes>
+                                        <additionalTimeStackSize>4</additionalTimeStackSize>
+                                        <showContents>false</showContents>
+                                        <overlayType>None</overlayType>
+                                    </li>
+                                </comps>
+                            </ThingDef>
+
+                            <ThingDef ParentName="DZ_VFEPD_WoodenLogs">
+                                <defName>DZ_VFEPD_WoodenLogsLarge</defName>
+                                <label>large wooden logs</label>
+                                <description>A large, impassable stack of wooden logs.</description>
+                                <graphicData>
+                                    <texPath>Things/Building/FarmProps/WoodenLogsLarge/WoodenLogsLarge</texPath>
+                                    <graphicClass>Graphic_Multi</graphicClass>
+                                    <drawSize>(3,3)</drawSize>
+                                    <shadowData>
+                                        <volume>(0.55, 0.30, 0.40)</volume>
+                                    </shadowData>
+                                </graphicData>
+                                <fillPercent>0.1</fillPercent>
+                                <statBases>
+                                    <MaxHitPoints>100</MaxHitPoints>
+                                    <WorkToBuild>300</WorkToBuild>
+                                    <Mass>20</Mass>
+                                    <Flammability>1</Flammability>
+                                </statBases>
+                                <size>(3,1)</size>
+                                <costList>
+                                    <WoodLog>50</WoodLog>
+                                </costList>
+                                <comps>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>5</maxNumberStacks>
+                                        <minTimeStoringTakes>100</minTimeStoringTakes>
+                                        <additionalTimeStackSize>4</additionalTimeStackSize>
+                                        <showContents>false</showContents>
+                                        <overlayType>None</overlayType>
                                     </li>
                                 </comps>
                             </ThingDef>
@@ -2080,52 +1844,7 @@
     <!--==========
      Add modded elements
     ==========-->
-    <!--Dubs Bad Hygiene, with conditional for Fertile Fields-->
-    <Operation Class="PatchOperationFindMod">
-        <mods>
-            <li>Vanilla Furniture Expanded - Props and Decor</li>
-        </mods>
-        <match Class="PatchOperationFindMod">
-            <mods>
-                <li>LWM's Deep Storage</li>
-            </mods>
-            <match Class="PatchOperationFindMod">
-                <mods>
-                    <li>Dubs Bad Hygiene</li>
-                </mods>
-                <match Class="PatchOperationFindMod">
-                    <mods>
-                        <li>Fertile Fields [1.1]</li>
-                    </mods>
-                    <match Class="PatchOperationSequence">
-                        <success>Always</success>
-                        <operations>
-                            <li Class="PatchOperationAdd">
-                                <xpath>/Defs/ThingDef[defName="DZ_VFEPD_BarrelGreen" or defName="DZ_VFEPD_PalletBarrelGreen"]/building/fixedStorageSettings/filter/thingDefs</xpath>
-                                <value>
-                                    <li>D9Ash</li>
-                                    <li>FecalSludge</li>
-                                </value>
-                            </li>
-                        </operations>
-                    </match>
-                    <nomatch Class="PatchOperationSequence">
-                        <success>Always</success>
-                        <operations>
-                            <li Class="PatchOperationAdd">
-                                <xpath>/Defs/ThingDef[defName="DZ_VFEPD_BarrelGreen" or defName="DZ_VFEPD_PalletBarrelGreen"]/building/fixedStorageSettings/filter/thingDefs</xpath>
-                                <value>
-                                    <li>FecalSludge</li>
-                                    <li>Biosolids</li>
-                                </value>
-                            </li>
-                        </operations>
-                    </nomatch>
-                </match>
-            </match>
-        </match>
-    </Operation>
-
+    <!--Dubs Bad Hygiene-->
     <Operation Class="PatchOperationFindMod">
         <mods>
             <li>Vanilla Furniture Expanded - Props and Decor</li>
@@ -2148,71 +1867,7 @@
                             <uiIconScale>0.75</uiIconScale>
                         </value>
                     </li>
-                    <!-- Need to make texture mask, and load DocWorld after.
-                    <li Class="PatchOperationReplace">
-                        <xpath>/Defs/ThingDef[defName="WashBucket"]/graphicData/texPath</xpath>
-                        <value>
-                            <texPath>Things/Building/MedievalProps/BucketWater/BucketWater</texPath>
-                        </value>
-                    </li>-->
-                    <!--Bucket Water as alternative for water tub -->
-                    <li Class="PatchOperationRemove">
-                        <xpath>/Defs/ThingDef[defName="VFEPD_BucketwithWater"]</xpath>
-                    </li>
-                    <li Class="PatchOperationAdd">
-                        <xpath>/Defs</xpath>
-                        <value>
-                            <ThingDef Name="DZ_VFEPD_BucketwithWater" ParentName="BasedHygieneMom">
-                                <defName>DZ_VFEPD_BucketwithWater</defName>
-                                <label>water bucket</label>
-                                <description>water bucket used for personal hygiene. Must be regularly refilled with fresh water. Can also be used for drinking if thirst is enabled.</description>
-                                <thingClass>DubsBadHygiene.Building_washbucket</thingClass>
-                                <graphicData>	
-                                    <texPath>Things/Building/MedievalProps/BucketWater/BucketWater</texPath>
-                                    <graphicClass>Graphic_Single</graphicClass>
-                                    <drawSize>(1,1)</drawSize>
-                                </graphicData>
-                                <staticSunShadowHeight Inherit="false" />
-                                <defaultPlacingRot Inherit="false" />
-                                <thingCategories>
-                                    <li>BuildingsHygiene</li>
-                                </thingCategories>
-                                <minifiedDef>MinifiedThing</minifiedDef>
-                                <rotatable>false</rotatable>
-                                <researchPrerequisites>
-                                    <li>MedievalProps</li>
-                                </researchPrerequisites>
-                                <altitudeLayer>Building</altitudeLayer>
-                                <passability>PassThroughOnly</passability>
-                                <statBases>
-                                    <MaxHitPoints>20</MaxHitPoints>
-                                    <WorkToBuild>130</WorkToBuild>
-                                    <Mass>5</Mass>
-                                    <Flammability>0.2</Flammability>
-                                </statBases>
-                                <tickerType>Rare</tickerType>
-                                <fillPercent>0.15</fillPercent>
-                                <size>(1,1)</size>
-                                <costList>
-                                    <WoodLog>10</WoodLog>
-                                </costList>
-                                <socialPropernessMatters>true</socialPropernessMatters>
-                                <costStuffCount Inherit="false" />
-                                <stuffCategories Inherit="false" />
-                                <uiIconScale>1</uiIconScale>
-                                <comps>
-                                    <li>
-                                        <compClass>CompColorable</compClass>
-                                    </li>
-                                    <li Class="CompProperties_Forbiddable"/>
-                                </comps>
-                            </ThingDef>
-                        </value>
-                    </li>
                     <!--Water Tank as alternative for water butt -->
-                    <li Class="PatchOperationRemove">
-                        <xpath>/Defs/ThingDef[defName="VFEPD_WaterTank"]</xpath>
-                    </li>
                     <li Class="PatchOperationAdd">
                         <xpath>/Defs</xpath>
                         <value>
@@ -2220,13 +1875,12 @@
                                 <defName>DZ_VFEPD_WaterTank</defName>
                                 <label>water tank</label>
                                 <description>Stores water for use by plumbed fixtures. If the contained water becomes contaminated, the tank must be drained. Pawns can wash their hands and drink (if thirst is enabled) from this building.</description>
-                                <thingClass>DubsBadHygiene.Building_Butt</thingClass>
-                                <graphicData>	
+                                <graphicData>
                                     <texPath>Things/Building/IndustrialProps/WaterTank/WaterTank</texPath>
                                     <graphicClass>Graphic_Single</graphicClass>
                                     <drawSize>(1,1)</drawSize>
                                     <shadowData>
-                                    <volume>(0.55, 0.30, 0.40)</volume>
+                                        <volume>(0.55, 0.30, 0.40)</volume>
                                     </shadowData>
                                 </graphicData>
                                 <staticSunShadowHeight Inherit="false" />
@@ -2258,18 +1912,14 @@
                                 <stuffCategories Inherit="false" />
                                 <uiIconScale>1</uiIconScale>
                                 <comps>
-                                    <li>
-                                        <compClass>CompColorable</compClass>
+                                    <li Class="DubsBadHygiene.CompProperties_WaterStorage">
+                                        <WaterStorageCap>1500</WaterStorageCap>
                                     </li>
-                                    <li Class="CompProperties_Forbiddable"/>
                                 </comps>
                             </ThingDef>
                         </value>
                     </li>
                     <!--Water Dispenser as an alternative to Fountains-->
-                    <li Class="PatchOperationRemove">
-                        <xpath>/Defs/ThingDef[defName="VFEPD_WaterDispenser"]</xpath>
-                    </li>
                     <li Class="PatchOperationAdd">
                         <xpath>/Defs</xpath>
                         <value>
@@ -2277,13 +1927,14 @@
                                 <defName>DZ_VFEPD_WaterDispenser</defName>
                                 <label>water dispenser</label>
                                 <description>A large, standing fresh water dispenser used for drinking.</description>
-                                <graphicData>	
+                                <graphicData>
                                     <texPath>Things/Building/KitchenProps/WaterDispenser/WaterDispenser</texPath>
                                     <graphicClass>Graphic_Multi</graphicClass>
                                     <drawSize>(2.5,2.5)</drawSize>
                                 </graphicData>
                                 <staticSunShadowHeight Inherit="false" />
-                                <defaultPlacingRot Inherit="false" />
+                                <defaultPlacingRot>South</defaultPlacingRot>
+                                <hasInteractionCell>False</hasInteractionCell>
                                 <thingCategories Inherit="false">
                                     <li>BuildingsHygiene</li>
                                 </thingCategories>
@@ -2299,15 +1950,22 @@
                             </ThingDef>
                         </value>
                     </li>
+                    <!-- New  texture mask-->
+                    <li Class="PatchOperationReplace">
+                        <xpath>/Defs/ThingDef[defName="WashBucket"]/graphicData/texPath</xpath>
+                        <value>
+                            <texPath>Mod_Content/VFE_PD/DZ_BucketWater</texPath>
+                        </value>
+                    </li>
                     <li Class="PatchOperationRemove">
-                        <xpath>/Defs/ThingDef[defName="VFEPD_WashingMachine"]</xpath>
+                        <xpath>/Defs/ThingDef[defName="VFEPD_BucketWater" or defName="VFEPD_WashingMachine" or defName="VFEPD_WaterDispenser" or defName="VFEPD_WaterTank"]</xpath>
                     </li>
                 </operations>
             </match>
         </match>
     </Operation>
 
-    <!--Fertile Fields-->
+    <!--RimFridge-->
     <Operation Class="PatchOperationFindMod">
         <mods>
             <li>Vanilla Furniture Expanded - Props and Decor</li>
@@ -2318,167 +1976,82 @@
             </mods>
             <match Class="PatchOperationFindMod">
                 <mods>
-                    <li>Fertile Fields [1.1]</li>
+                    <li>[KV] RimFridge</li>
                 </mods>
                 <match Class="PatchOperationSequence">
                     <success>Always</success>
                     <operations>
-                        <li Class="PatchOperationAdd">
-                            <xpath>/Defs/ThingDef[defName="DZ_VFEPD_BarrelGreen" or defName="DZ_VFEPD_PalletBarrelGreen"]/building/fixedStorageSettings/filter/thingDefs</xpath>
-                            <value>
-                                <li>RawCompost</li>
-                                <li>Fertilizer</li>
-                                <li>PileofDirt</li>
-                                <li>SandPile</li>
-                                <li>RFFClay</li>
-                                <li>RottedMush</li>
-                                <li>CrushedRocks</li>
-                            </value>
-                        </li>
-                        <li Class="PatchOperationAdd">
-                            <xpath>/Defs/ThingDef[defName="DZ_VFEPD_HayBaleSmall"]/building/fixedStorageSettings/filter/thingDefs</xpath>
-                            <value>
-                                <li>PlantScraps</li>
-                            </value>
-                        </li>
-                        <!--Concrete bags / Storage bags-->
-                        <li Class="PatchOperationAdd">
-                            <xpath>/Defs/ThingDef[defName="DZ_VFEPD_ConcreteBags"]/building/fixedStorageSettings/filter</xpath>
-                            <value>
-                                <thingDefs>
-                                    <li>RawCompost</li>
-                                    <li>Fertilizer</li>
-                                    <li>PileofDirt</li>
-                                    <li>SandPile</li>
-                                    <li>RFFClay</li>
-                                    <li>RottedMush</li>
-                                    <li>CrushedRocks</li>
-                                </thingDefs>
-                            </value>
-                        </li>
-                    </operations>
-                </match>
-            </match>
-        </match>
-    </Operation>
-
-    <!--Rimatomics-->
-    <Operation Class="PatchOperationFindMod">
-        <mods>
-            <li>Vanilla Furniture Expanded - Props and Decor</li>
-        </mods>
-        <match Class="PatchOperationFindMod">
-            <mods>
-                <li>LWM's Deep Storage</li>
-            </mods>
-            <match Class="PatchOperationFindMod">
-                <mods>
-                    <li>Rimatomics</li>
-                </mods>
-                <match Class="PatchOperationSequence">
-                    <success>Always</success>
-                    <operations>
-                        <li Class="PatchOperationAdd">
-                            <xpath>/Defs/ThingDef[defName="DZ_VFEPD_BarrelGreen" or defName="DZ_VFEPD_PalletBarrelGreen"]/building/fixedStorageSettings/filter/thingDefs</xpath>
-                            <value>
-                                <li>NuclearWaste</li>
-                            </value>
-                        </li>
-                        <!--Toxic waste barrel-->
                         <li Class="PatchOperationRemove">
-                            <xpath>/Defs/ThingDef[defName="VFEPD_ToxicWasteBarrel"]</xpath>
+                            <xpath>/Defs/ThingDef[defName="VFEPD_Fridge"]</xpath>
                         </li>
                         <li Class="PatchOperationAdd">
                             <xpath>/Defs</xpath>
                             <value>
-                                <ThingDef Name="DZ_VFEPD_ToxicWasteBarrel" ParentName="LWM_Skip">
-                                    <defName>VFEPD_ToxicWasteBarrel</defName>
-                                    <label>toxic waste barrel</label>
-                                    <description>A small barrel of toxic waste.</description>
-                                    <graphicData>	
-                                    <texPath>Things/Building/PowerProps/ToxicWasteBarrel/ToxicWasteBarrel</texPath>
-                                        <graphicClass>Graphic_Single</graphicClass>
-                                        <drawSize>(1,1)</drawSize>
-                                        <shadowData>
-                                            <volume>(0.55, 0.30, 0.40)</volume>
-                                        </shadowData>
+                                <ThingDef Name="DZ_VFEPD_Fridge" ParentName="LWM_DeepRimFridge">
+                                    <defName>DZ_VFEPD_Fridge</defName>
+                                    <label>fridge</label>
+                                    <description>A fridge cabinet. Can hold food and freeze it. Easier to build and use than a deep fridge.</description>
+                                    <graphicData>
+                                        <texPath>Things/Building/KitchenProps/Fridge/Fridge</texPath>
+                                        <graphicClass>Graphic_Multi</graphicClass>
+                                        <drawSize>(3,3)</drawSize>
                                     </graphicData>
-                                    <staticSunShadowHeight Inherit="false" />
-                                    <defaultPlacingRot Inherit="false" />
-                                    <rotatable>false</rotatable>
+                                    <staticSunShadowHeight Inherit="False" />
+                                    <defaultPlacingRot>South</defaultPlacingRot>
                                     <researchPrerequisites>
-                                        <li>IndustrialProps</li>
+                                        <li>KitchenProps</li>
                                     </researchPrerequisites>
-                                    <altitudeLayer>Building</altitudeLayer>
-                                    <passability>PassThroughOnly</passability>
-                                    <fillPercent>0.3</fillPercent>
+                                    <terrainAffordanceNeeded>Light</terrainAffordanceNeeded>
+                                    <castEdgeShadows>False</castEdgeShadows>
+                                    <blockWind>False</blockWind>
                                     <statBases>
-                                        <MaxHitPoints>200</MaxHitPoints>
-                                        <WorkToBuild>130</WorkToBuild>
-                                        <Mass>50</Mass>
-                                        <Flammability>0.2</Flammability>
+                                        <MaxHitPoints>150</MaxHitPoints>
+                                        <WorkToBuild>500</WorkToBuild>
+                                        <Mass>30</Mass>
+                                        <Flammability>1.0</Flammability>
                                     </statBases>
                                     <size>(1,1)</size>
-                                    <costList>
-                                        <Steel>40</Steel>
+                                    <costList Inherit="False">
+                                        <Steel>50</Steel>
+                                        <ComponentIndustrial>2</ComponentIndustrial>
                                     </costList>
-                                    <costStuffCount Inherit="false" />
-                                    <stuffCategories Inherit="false" />
-                                    <uiIconScale>1</uiIconScale>
-                                    <building Inherit="false">
-                                        <ignoreStoredThingsBeauty>false</ignoreStoredThingsBeauty>
-                                        <preventDeteriorationOnTop>false</preventDeteriorationOnTop>
-                                        <fixedStorageSettings>
-                                            <filter>
-                                                <thingDefs>
-                                                    <li>NuclearWaste</li>
-                                                </thingDefs>
-                                            </filter>
-                                        </fixedStorageSettings>
-                                        <defaultStorageSettings>
-                                            <priority>Important</priority>
-                                            <filter>
-                                            </filter>
-                                        </defaultStorageSettings>
-                                        <isInert>true</isInert>
-                                    </building>
-                                    <comps>
-                                        <li Class="LWM.DeepStorage.Properties">
-                                            <maxNumberStacks>8</maxNumberStacks>
-                                            <minTimeStoringTakes>20</minTimeStoringTakes>
+                                    <uiIconScale>0.5</uiIconScale>
+                                    <comps Inherit="False">
+                                        <li Class="CompProperties_Flickable"/>
+                                        <li Class="CompProperties_Breakdownable"/>
+                                        <li Class="CompProperties_Glower">
+                                            <glowRadius>2.5</glowRadius>
+                                            <glowColor>(89,188,255,0)</glowColor>
+                                        </li>
+                                        <li Class="RimFridge.CompProperties_Refrigerator">
+                                            <drinksBestCold>
+                                                <li>Beer</li>
+                                                <li>RC2_Ale</li>
+                                                <li>RC2_Cider</li>
+                                                <li>RC2_Grog</li>
+                                                <li>RC2_Stout</li>
+                                            </drinksBestCold>
+                                            <findAllRottableForFilters>true</findAllRottableForFilters>
+                                        </li>
+                                        <li Class="CompProperties_Power">
+                                            <compClass>CompPowerTrader</compClass>
+                                            <basePowerConsumption>120</basePowerConsumption>
+                                        </li>
+                                        <li Class='LWM.DeepStorage.Properties'>
+                                            <minNumberStacks>2</minNumberStacks>
+                                            <maxNumberStacks>5</maxNumberStacks>
+                                            <maxMassOfStoredItem>100</maxMassOfStoredItem>
+                                            <minTimeStoringTakes>25</minTimeStoringTakes>
                                             <additionalTimeEachStack>10</additionalTimeEachStack>
+                                            <additionalTimeEachDef>10</additionalTimeEachDef>
                                             <showContents>false</showContents>
-                                            <overlayType>SumOfItemsPerCell</overlayType>
+                                            <overlayType>None</overlayType>
                                         </li>
                                     </comps>
                                 </ThingDef>
                             </value>
                         </li>
                     </operations>
-                </match>
-            </match>
-        </match>
-    </Operation>
-
-    <!--Rimefeller-->
-    <Operation Class="PatchOperationFindMod">
-        <mods>
-            <li>Vanilla Furniture Expanded - Props and Decor</li>
-        </mods>
-        <match Class="PatchOperationFindMod">
-            <mods>
-                <li>LWM's Deep Storage</li>
-            </mods>
-            <match Class="PatchOperationFindMod">
-                <mods>
-                    <li>Rimefeller</li>
-                </mods>
-                <match Class="PatchOperationAdd">
-                    <xpath>/Defs/ThingDef[defName="DZ_VFEPD_BarrelGreen" or defName="DZ_VFEPD_PalletBarrelGreen"]/building/fixedStorageSettings/filter/thingDefs</xpath>
-                    <value>
-                        <li>OilBarrel</li>
-                        <li>Napalm</li>
-                    </value>
                 </match>
             </match>
         </match>
@@ -2588,143 +2161,6 @@
                     </li>
                     <li Class="PatchOperationRemove">
                         <xpath>/Defs/ThingDef[defName="VFEPD_Microwave" or defName="VFEPD_Oven" or defName="VFEPD_Cooker"]</xpath>
-                    </li>
-                </operations>
-            </match>
-        </match>
-    </Operation>
-
-    <!--Vanilla Brewing Expanded-->
-    <Operation Class="PatchOperationFindMod">
-        <mods>
-            <li>Vanilla Furniture Expanded - Props and Decor</li>
-        </mods>
-        <match Class="PatchOperationFindMod">
-            <mods>
-                <li>LWM's Deep Storage</li>
-            </mods>
-            <match Class="PatchOperationFindMod">
-                <mods>
-                    <li>Vanilla Brewing Expanded</li>
-                </mods>
-                <match Class="PatchOperationAdd">
-                    <xpath>/Defs/ThingDef[defName="DZ_VFEPD_WineRack"]/building/fixedStorageSettings/filter/thingDefs</xpath>
-                    <value>
-                        <li>VBE_AmbrandyAwful</li>
-                        <li>VBE_AmbrandyPoor</li>
-                        <li>VBE_AmbrandyNormal</li>
-                        <li>VBE_AmbrandyGood</li>
-                        <li>VBE_AmbrandyExcellent</li>
-                        <li>VBE_AmbrandyMasterwork</li>
-                        <li>VBE_AmbrandyLegendary</li>
-                        <li>VBE_Gin</li>
-                        <li>VBE_Tequila</li>
-                        <li>VBE_Vodka</li>
-                        <li>VBE_Whiskey</li>
-                    </value>
-                </match>
-            </match>
-        </match>
-    </Operation>
-
-    <!--Vanilla Factions Expanded - Medieval-->
-    <Operation Class="PatchOperationFindMod">
-        <mods>
-            <li>Vanilla Furniture Expanded - Props and Decor</li>
-        </mods>
-        <match Class="PatchOperationFindMod">
-            <mods>
-                <li>LWM's Deep Storage</li>
-            </mods>
-            <match Class="PatchOperationFindMod">
-                <mods>
-                    <li>Vanilla Factions Expanded - Medieval</li>
-                </mods>
-                <match Class="PatchOperationAdd">
-                    <xpath>/Defs/ThingDef[defName="DZ_VFEPD_WineRack"]/building/fixedStorageSettings/filter/thingDefs</xpath>
-                    <value>
-                        <li>VFEM_Wine</li>
-                    </value>
-                </match>
-            </match>
-        </match>
-    </Operation>
-
-    <!--RimFridge-->
-    <Operation Class="PatchOperationFindMod">
-        <mods>
-            <li>Vanilla Furniture Expanded - Props and Decor</li>
-        </mods>
-        <match Class="PatchOperationFindMod">
-            <mods>
-                <li>LWM's Deep Storage</li>
-            </mods>
-            <match Class="PatchOperationSequence">
-                <success>Always</success>
-                <operations>
-                    <li Class="PatchOperationRemove">
-                        <xpath>/Defs/ThingDef[defName="VFEPD_Fridge"]</xpath>
-                    </li>
-                    <li Class="PatchOperationAdd">
-                        <xpath>/Defs</xpath>
-                        <value>
-                            <ThingDef Name="DZ_VFEPD_Fridge" ParentName="LWM_DeepRimFridge">
-                                <defName>DZ_VFEPD_Fridge</defName>
-                                <label>fridge</label>
-                                <description>A fridge cabinet. Can hold food and freeze it. Easier to build and use than a deep fridge.</description>
-                                <graphicData>
-                                    <texPath>Things/Building/KitchenProps/Fridge/Fridge</texPath>
-                                    <graphicClass>Graphic_Multi</graphicClass>
-                                    <drawSize>(3,3)</drawSize>
-                                </graphicData>
-                                <staticSunShadowHeight Inherit="false" />
-                                <researchPrerequisites>
-                                    <li>KitchenProps</li>
-                                </researchPrerequisites>
-                                <terrainAffordanceNeeded>Light</terrainAffordanceNeeded>
-                                <castEdgeShadows>False</castEdgeShadows>
-                                <blockWind>true</blockWind>
-                                <statBases>
-                                    <MaxHitPoints>150</MaxHitPoints>
-                                    <WorkToBuild>500</WorkToBuild>
-                                    <Mass>30</Mass>
-                                    <Flammability>1.0</Flammability>
-                                </statBases>
-                                <size>(1,1)</size>
-                                <costList Inherit="false">
-                                    <Steel>50</Steel>
-                                    <ComponentIndustrial>2</ComponentIndustrial>
-                                </costList>
-                                <uiIconScale>0.5</uiIconScale>
-                                <comps Inherit="false">
-                                    <li Class="CompProperties_Flickable"/>
-                                    <li Class="CompProperties_Breakdownable"/>
-                                    <li Class="RimFridge.CompProperties_Refrigerator"> 
-                                        <drinksBestCold>
-                                            <li>Beer</li>
-                                            <li>RC2_Ale</li>
-                                            <li>RC2_Cider</li>
-                                            <li>RC2_Grog</li>
-                                            <li>RC2_Stout</li>
-                                        </drinksBestCold>
-                                        <findAllRottableForFilters>true</findAllRottableForFilters>
-                                    </li>
-                                    <li Class="CompProperties_Power">
-                                        <compClass>CompPowerTrader</compClass>
-                                        <basePowerConsumption>120</basePowerConsumption>
-                                    </li>
-                                    <li Class='LWM.DeepStorage.Properties'>
-                                        <minNumberStacks>2</minNumberStacks>
-                                        <maxNumberStacks>4</maxNumberStacks>
-                                        <maxMassOfStoredItem>100</maxMassOfStoredItem>
-                                        <minTimeStoringTakes>25</minTimeStoringTakes>
-                                        <additionalTimeEachStack>10</additionalTimeEachStack>
-                                        <additionalTimeEachDef>10</additionalTimeEachDef>
-                                        <overlayType>SumOfAllItems</overlayType>
-                                    </li>
-                                </comps>
-                            </ThingDef>
-                        </value>
                     </li>
                 </operations>
             </match>

--- a/Patches/VFE_Usable_Props.xml
+++ b/Patches/VFE_Usable_Props.xml
@@ -800,6 +800,1295 @@
                             </ThingDef>
                         </value>
                     </li>
+                    <!--Wooden Logs-->
+                    <li Class="PatchOperationRemove">
+                        <xpath>/Defs/ThingDef[defName="VFEPD_WoodenLogs" or defName="VFEPD_WoodenLogsLarge"]</xpath>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <DesignatorDropdownGroupDef>
+                                <defName>DZ_Storage_WoodenLogs</defName>
+                            </DesignatorDropdownGroupDef>
+                        </value>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <ThingDef Name="DZ_VFEPD_WoodenLogs" ParentName="LWM_Skip">
+                                <defName>DZ_VFEPD_WoodenLogs</defName>
+                                <label>wooden logs</label>
+                                <description>A small, passable stack of wooden logs.</description>
+                                <graphicData>	
+                                    <texPath>Things/Building/FarmProps/WoodenLogs/WoodenLogs</texPath>
+                                    <graphicClass>Graphic_Multi</graphicClass>
+                                    <drawSize>(1.5,1.5)</drawSize>
+                                    <shadowData>
+                                        <volume>(0.55, 0.30, 0.40)</volume>
+                                    </shadowData>
+                                </graphicData>
+                                <staticSunShadowHeight Inherit="false" />
+                                <defaultPlacingRot>South</defaultPlacingRot>
+                                <researchPrerequisites>
+                                    <li>FarmProps</li>
+                                </researchPrerequisites>
+                                <altitudeLayer>Building</altitudeLayer>
+                                <passability>PassThroughOnly</passability>
+                                <fillPercent>0.4</fillPercent>
+                                <statBases>
+                                    <MaxHitPoints>70</MaxHitPoints>
+                                    <WorkToBuild>100</WorkToBuild>
+                                    <Mass>5</Mass>
+                                    <Flammability>1</Flammability>
+                                </statBases>
+                                <size>(1,1)</size>
+                                <costList>
+                                    <WoodLog>20</WoodLog>
+                                </costList>
+                                <costStuffCount Inherit="false" />
+                                <stuffCategories Inherit="false" />
+                                <uiIconScale>1</uiIconScale>
+                                <designatorDropdown>DZ_Storage_WoodenLogs</designatorDropdown>
+                                <building Inherit="false">
+                                    <ignoreStoredThingsBeauty>true</ignoreStoredThingsBeauty>
+                                    <preventDeteriorationOnTop>true</preventDeteriorationOnTop>
+                                    <fixedStorageSettings Inherit="false">
+                                        <filter>
+                                            <thingDefs>
+                                                <li>WoodLog</li>
+                                            </thingDefs>
+                                        </filter>
+                                    </fixedStorageSettings>
+                                    <defaultStorageSettings>
+                                        <priority>Important</priority>
+                                        <filter>
+                                        </filter>
+                                    </defaultStorageSettings>
+                                    <isInert>true</isInert>
+                                </building>
+                                <comps>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>3</maxNumberStacks>
+                                        <minTimeStoringTakes>50</minTimeStoringTakes>
+                                        <additionalTimeStackSize>4</additionalTimeStackSize>
+                                        <showContents>false</showContents>
+                                        <overlayType>SumOfAllItems</overlayType>
+                                    </li>
+                                </comps>
+                            </ThingDef>
+
+                            <ThingDef ParentName="DZ_VFEPD_WoodenLogs">
+                                <defName>DZ_VFEPD_WoodenLogsLarge</defName>
+                                <label>large wooden logs</label>
+                                <description>A large, impassable stack of wooden logs.</description>
+                                <graphicData>	
+                                    <texPath>Things/Building/FarmProps/WoodenLogsLarge/WoodenLogsLarge</texPath>
+                                    <graphicClass>Graphic_Multi</graphicClass>
+                                    <drawSize>(3,3)</drawSize>
+                                    <shadowData>
+                                        <volume>(0.55, 0.30, 0.40)</volume>
+                                    </shadowData>
+                                </graphicData>
+                                <fillPercent>0.1</fillPercent>
+                                <statBases>
+                                    <MaxHitPoints>100</MaxHitPoints>
+                                    <WorkToBuild>300</WorkToBuild>
+                                    <Mass>20</Mass>
+                                    <Flammability>1</Flammability>
+                                </statBases>
+                                <size>(3,1)</size>
+                                <costList>
+                                    <WoodLog>50</WoodLog>
+                                </costList>
+                                <comps>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>4</maxNumberStacks>
+                                        <minTimeStoringTakes>100</minTimeStoringTakes>
+                                        <additionalTimeStackSize>4</additionalTimeStackSize>
+                                        <showContents>false</showContents>
+                                        <overlayType>SumOfAllItems</overlayType>
+                                    </li>
+                                </comps>
+                            </ThingDef>
+                        </value>
+                    </li>
+                    <!--Medieval Weapon Racks-->
+                    <li Class="PatchOperationRemove">
+                        <xpath>/Defs/ThingDef[defName="VFEPD_WeaponRackEmpty" or defName="VFEPD_WeaponRackSwords" or defName="VFEPD_WeaponRackSpears"]</xpath>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <DesignatorDropdownGroupDef>
+                                <defName>DZ_Storage_WeaponRacks</defName>
+                            </DesignatorDropdownGroupDef>
+                        </value>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <ThingDef Name="DZ_VFEPD_WeaponRackEmpty" ParentName="LWM_Big_Shelf">
+                                <defName>DZ_VFEPD_WeaponRackEmpty</defName>
+                                <label>weapon rack</label>
+                                <description>A long weapon rack. It can store weapons. Items stored here can deteriorate</description>
+                                <graphicData>	
+                                    <texPath>Things/Building/MedievalProps/WeaponRackEmpty/WeaponRackEmpty</texPath>
+                                    <graphicClass>Graphic_Multi</graphicClass>
+                                    <drawSize>(2,2)</drawSize>
+                                    <shadowData>
+                                        <volume>(0.55, 0.30, 0.40)</volume>
+                                    </shadowData>
+                                </graphicData>
+                                <staticSunShadowHeight Inherit="false" />
+                                <defaultPlacingRot>South</defaultPlacingRot>
+                                <researchPrerequisites>
+                                    <li>MedievalProps</li>
+                                </researchPrerequisites>
+                                <altitudeLayer>Building</altitudeLayer>
+                                <passability>PassThroughOnly</passability>
+                                <fillPercent>0.3</fillPercent>
+                                <statBases>
+                                    <MaxHitPoints>70</MaxHitPoints>
+                                    <WorkToBuild>150</WorkToBuild>
+                                    <Mass>15</Mass>
+                                    <Beauty>15</Beauty>
+                                    <Flammability>0.7</Flammability>
+                                </statBases>
+                                <size>(2,1)</size>
+                                <costList>
+                                    <WoodLog>50</WoodLog>
+                                </costList>
+                                <costStuffCount Inherit="false" />
+                                <stuffCategories Inherit="false" />
+                                <uiIconScale>1</uiIconScale>
+                                <designatorDropdown>DZ_Storage_WeaponRacks</designatorDropdown>
+                                <building Inherit="false">
+                                    <ignoreStoredThingsBeauty>false</ignoreStoredThingsBeauty>
+                                    <preventDeteriorationOnTop>false</preventDeteriorationOnTop>
+                                    <fixedStorageSettings>
+                                        <filter>
+                                            <categories>
+                                                <li>Weapons</li>
+                                            </categories>
+                                        </filter>
+                                    </fixedStorageSettings>
+                                    <defaultStorageSettings>
+                                        <priority>Important</priority>
+                                        <filter>
+                                        </filter>
+                                    </defaultStorageSettings>
+                                    <isInert>true</isInert>
+                                </building>
+                                <comps>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>4</maxNumberStacks>
+                                        <minTimeStoringTakes>50</minTimeStoringTakes>
+                                        <additionalTimeEachStack>10</additionalTimeEachStack>
+                                        <maxTotalMass>30</maxTotalMass>
+                                        <showContents>true</showContents>
+                                        <overlayType>SumOfAllItems</overlayType>
+                                    </li>
+                                </comps>
+                            </ThingDef>
+
+                            <ThingDef Name="DZ_VFEPD_WeaponRackSwords" ParentName="DZ_VFEPD_WeaponRackEmpty">
+                                <defName>DZ_VFEPD_WeaponRackSwords</defName>
+                                <label>weapon rack</label>
+                                <description>A long weapon rack. It can store weapons. Items stored here will not be visible but can deteriorate.</description>
+                                <graphicData>
+                                    <texPath>Things/Building/MedievalProps/WeaponRackSwords/WeaponRackSwords</texPath>
+                                    <graphicClass>Graphic_Multi</graphicClass>
+                                    <drawSize>(2,2)</drawSize>
+                                </graphicData>
+                                <building Inherit="true">
+                                    <ignoreStoredThingsBeauty>true</ignoreStoredThingsBeauty>
+                                </building>
+                                <comps>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>4</maxNumberStacks>
+                                        <minTimeStoringTakes>50</minTimeStoringTakes>
+                                        <additionalTimeEachStack>10</additionalTimeEachStack>
+                                        <maxTotalMass>30</maxTotalMass>
+                                        <showContents>false</showContents>
+                                        <overlayType>SumOfAllItems</overlayType>
+                                    </li>
+                                </comps>
+                            </ThingDef>
+
+                            <ThingDef ParentName="DZ_VFEPD_WeaponRackSwords">
+                                <defName>DZ_VFEPD_WeaponRackSpearss</defName>
+                                <graphicData>
+                                    <texPath>Things/Building/MedievalProps/WeaponRackSpears/WeaponRackSpears</texPath>
+                                    <graphicClass>Graphic_Multi</graphicClass>
+                                    <drawSize>(2,2)</drawSize>
+                                    <shadowData>
+                                        <volume>(0.55, 0.30, 0.40)</volume>
+                                    </shadowData>
+                                </graphicData>
+                            </ThingDef>
+                        </value>
+                    </li>
+                    <!--Medieval Armor Stands-->
+                    <li Class="PatchOperationRemove">
+                        <xpath>/Defs/ThingDef[defName="VFEPD_ArmorStandEmpty" or defName="VFEPD_ArmorStandFull"]</xpath>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <DesignatorDropdownGroupDef>
+                                <defName>DZ_Storage_ArmorRacks</defName>
+                            </DesignatorDropdownGroupDef>
+                        </value>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <ThingDef Name="DZ_VFEPD_ArmorStandEmpty" ParentName="LWM_Big_Shelf">
+                                <defName>DZ_VFEPD_ArmorStandEmpty</defName>
+                                <label>armor stand</label>
+                                <description>An armor stand. It can store apparel. Items stored can deteriorate</description>
+                                <graphicData>	
+                                    <texPath>Things/Building/MedievalProps/ArmorStandEmpty/ArmorStandEmpty</texPath>
+                                    <graphicClass>Graphic_Multi</graphicClass>
+                                    <drawSize>(2,2)</drawSize>
+                                </graphicData>
+                                <staticSunShadowHeight Inherit="false" />
+                                <defaultPlacingRot>South</defaultPlacingRot>
+                                <researchPrerequisites>
+                                    <li>MedievalProps</li>
+                                </researchPrerequisites>
+                                <altitudeLayer>Building</altitudeLayer>
+                                <passability>PassThroughOnly</passability>
+                                <fillPercent>0.3</fillPercent>
+                                <statBases>
+                                    <MaxHitPoints>50</MaxHitPoints>
+                                    <WorkToBuild>100</WorkToBuild>
+                                    <Mass>15</Mass>
+                                    <Beauty>15</Beauty>
+                                    <Flammability>0.7</Flammability>
+                                </statBases>
+                                <size>(1,1)</size>
+                                <costList>
+                                    <WoodLog>40</WoodLog>
+                                </costList>
+                                <costStuffCount Inherit="false" />
+                                <stuffCategories Inherit="false" />
+                                <uiIconScale>0.7</uiIconScale>
+                                <designatorDropdown>DZ_Storage_ArmorRacks</designatorDropdown>
+                                <building Inherit="false">
+                                    <ignoreStoredThingsBeauty>false</ignoreStoredThingsBeauty>
+                                    <preventDeteriorationOnTop>false</preventDeteriorationOnTop>
+                                    <fixedStorageSettings>
+                                        <filter>
+                                            <categories>
+                                                <li>Apparel</li>
+                                            </categories>
+                                        </filter>
+                                    </fixedStorageSettings>
+                                    <defaultStorageSettings>
+                                        <priority>Important</priority>
+                                        <filter>
+                                        </filter>
+                                    </defaultStorageSettings>
+                                    <isInert>true</isInert>
+                                </building>
+                                <comps>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>4</maxNumberStacks>
+                                        <minTimeStoringTakes>150</minTimeStoringTakes>
+                                        <additionalTimeEachStack>10</additionalTimeEachStack>
+                                        <maxTotalMass>30</maxTotalMass>
+                                        <showContents>true</showContents>
+                                        <overlayType>SumOfAllItems</overlayType>
+                                    </li>
+                                </comps>
+                            </ThingDef>
+
+                            <ThingDef ParentName="DZ_VFEPD_ArmorStandEmpty">
+                                <defName>DZ_VFEPD_ArmorStandFull</defName>
+                                <label>armor stand</label>
+                                <description>An armor stand. It can store apparel. Items stored here will not be visible but will deteriorate</description>
+                                <graphicData>	
+                                    <texPath>Things/Building/MedievalProps/ArmorStandFull/ArmorStandFull</texPath>
+                                    <graphicClass>Graphic_Multi</graphicClass>
+                                    <drawSize>(2,2)</drawSize>
+                                </graphicData>
+                                <building Inherit="true">
+                                    <ignoreStoredThingsBeauty>true</ignoreStoredThingsBeauty>
+                                </building>
+                                <comps>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>4</maxNumberStacks>
+                                        <minTimeStoringTakes>50</minTimeStoringTakes>
+                                        <additionalTimeEachStack>10</additionalTimeEachStack>
+                                        <maxTotalMass>30</maxTotalMass>
+                                        <showContents>false</showContents>
+                                        <overlayType>SumOfAllItems</overlayType>
+                                    </li>
+                                </comps>
+                            </ThingDef>
+                        </value>
+                    </li>
+                    <!--Medieval Chests.-->
+                    <li Class="PatchOperationRemove">
+                        <xpath>/Defs/ThingDef[defName="VFEPD_WoodenChest" or defName="VFEPD_WoodenChestLarge"]</xpath>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <DesignatorDropdownGroupDef>
+                                <defName>DZ_Storage_Chests</defName>
+                            </DesignatorDropdownGroupDef>
+                        </value>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <ThingDef Name="DZ_VFEPD_WoodenChest" ParentName="LWM_Big_Shelf">
+                                <defName>DZ_VFEPD_WoodenChest</defName>
+                                <label>wooden chest</label>
+                                <description>A medium size wooden chest for storing miscellaneous items. Items stored in this will not deteriorate, even if outside.</description>
+                                <graphicData>	
+                                    <texPath>Things/Building/MedievalProps/Chest/Chest</texPath>
+                                    <graphicClass>Graphic_Multi</graphicClass>
+                                    <drawSize>(1,1)</drawSize>
+                                    <shadowData>
+                                        <volume>(0.55, 0.30, 0.40)</volume>
+                                    </shadowData>
+                                </graphicData>
+                                <staticSunShadowHeight Inherit="false" />
+                                <defaultPlacingRot>South</defaultPlacingRot>
+                                <researchPrerequisites>
+                                    <li>MedievalProps</li>
+                                </researchPrerequisites>
+                                <altitudeLayer>Building</altitudeLayer>
+                                <passability>PassThroughOnly</passability>
+                                <fillPercent>0.3</fillPercent>
+                                <statBases>
+                                    <MaxHitPoints>70</MaxHitPoints>
+                                    <WorkToBuild>150</WorkToBuild>
+                                    <Mass>15</Mass>
+                                    <Flammability>0.7</Flammability>
+                                </statBases>
+                                <size>(1,1)</size>
+                                <costList>
+                                    <WoodLog>40</WoodLog>
+                                </costList>
+                                <costStuffCount Inherit="false" />
+                                <stuffCategories Inherit="false" />
+                                <uiIconScale>1</uiIconScale>
+                                <designatorDropdown>DZ_Storage_Chests</designatorDropdown>
+                                <building Inherit="false">
+                                    <ignoreStoredThingsBeauty>true</ignoreStoredThingsBeauty>
+                                    <preventDeteriorationOnTop>true</preventDeteriorationOnTop>
+                                    <defaultStorageSettings>
+                                        <priority>Important</priority>
+                                        <filter>
+                                        </filter>
+                                    </defaultStorageSettings>
+                                    <isInert>true</isInert>
+                                </building>
+                                <comps>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>3</maxNumberStacks>
+                                        <minTimeStoringTakes>50</minTimeStoringTakes>
+                                        <additionalTimeEachStack>75</additionalTimeEachStack>
+                                        <maxTotalMass>45</maxTotalMass><!--About a medium sized body-->
+                                        <additionalTimeEachDef>20</additionalTimeEachDef>
+                                        <showContents>false</showContents>
+                                        <overlayType>SumOfAllItems</overlayType>
+                                    </li>
+                                </comps>
+                            </ThingDef>
+
+                            <ThingDef ParentName="DZ_VFEPD_WoodenChest">
+                                <defName>DZ_VFEPD_WoodenChestLarge</defName>
+                                <label>large wooden box</label>
+                                <description>A large size wooden chest for storing miscellaneous items. Items stored in this will not deteriorate, even if outside.</description>
+                                <graphicData>	
+                                    <texPath>Things/Building/MedievalProps/ChestLarge/ChestLarge</texPath>
+                                    <graphicClass>Graphic_Multi</graphicClass>
+                                    <drawSize>(2,2)</drawSize>
+                                    <shadowData>
+                                        <volume>(0.55, 0.30, 0.40)</volume>
+                                    </shadowData>
+                                </graphicData>
+                                <statBases>
+                                    <MaxHitPoints>40</MaxHitPoints>
+                                    <WorkToBuild>100</WorkToBuild>
+                                    <Mass>8</Mass>
+                                    <Flammability>0.7</Flammability>
+                                </statBases>
+                                <size>(2,1)</size>
+                                <costList>
+                                    <WoodLog>60</WoodLog>
+                                </costList>
+                                <comps>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>3</maxNumberStacks>
+                                        <minTimeStoringTakes>50</minTimeStoringTakes>
+                                        <additionalTimeEachStack>75</additionalTimeEachStack>
+                                        <additionalTimeEachDef>20</additionalTimeEachDef>
+                                        <showContents>false</showContents>
+                                        <overlayType>SumOfAllItems</overlayType>
+                                    </li>
+                                </comps>
+                            </ThingDef>
+                        </value>
+                    </li>
+                    <!--Wagon. Because the object is 1x3, it can't show contents because they would be on top of the handle.-->
+                    <li Class="PatchOperationRemove">
+                        <xpath>/Defs/ThingDef[defName="VFEPD_WoodenWagon"]</xpath>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <ThingDef Name="DZ_VFEPD_WoodenWagon" ParentName="LWM_Big_Shelf">
+                                <defName>DZ_VFEPD_WoodenWagon</defName>
+                                <label>wooden wagon</label>
+                                <description>A large stationary wagon. Can hold various things.</description>
+                                <graphicData>	
+                                    <texPath>Things/Building/FarmProps/Wagon/Wagon</texPath>
+                                    <graphicClass>Graphic_Multi</graphicClass>
+                                    <drawSize>(3,3)</drawSize>
+                                    <shadowData>
+                                        <volume>(0.55, 0.30, 0.40)</volume>
+                                    </shadowData>
+                                </graphicData>
+                                <staticSunShadowHeight Inherit="false" />
+                                <defaultPlacingRot>South</defaultPlacingRot>
+                                <researchPrerequisites>
+                                    <li>FarmProps</li>
+                                </researchPrerequisites>
+                                <altitudeLayer>Building</altitudeLayer>
+                                <passability>PassThroughOnly</passability>
+                                <fillPercent>0.5</fillPercent>
+                                <statBases>
+                                    <MaxHitPoints>100</MaxHitPoints>
+                                    <WorkToBuild>200</WorkToBuild>
+                                    <Mass>5</Mass>
+                                    <Beauty>15</Beauty>
+                                    <Flammability>1</Flammability>
+                                </statBases>
+                                <size>(1,3)</size>
+                                <costList>
+                                    <WoodLog>60</WoodLog>
+                                </costList>
+                                <costStuffCount Inherit="false" />
+                                <stuffCategories Inherit="false" />
+                                <uiIconScale>0.9</uiIconScale>
+                                <building Inherit="false">
+                                    <ignoreStoredThingsBeauty>false</ignoreStoredThingsBeauty>
+                                    <preventDeteriorationOnTop>false</preventDeteriorationOnTop>
+                                    <defaultStorageSettings>
+                                        <priority>Important</priority>
+                                        <filter>
+                                        </filter>
+                                    </defaultStorageSettings>
+                                    <isInert>true</isInert>
+                                </building>
+                                <comps>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>3</maxNumberStacks>
+                                        <minTimeStoringTakes>150</minTimeStoringTakes>
+                                        <additionalTimeEachStack>50</additionalTimeEachStack>
+                                        <maxTotalMass>90</maxTotalMass>
+                                        <additionalTimeEachDef>20</additionalTimeEachDef>
+                                        <showContents>false</showContents>
+                                        <overlayType>SumOfItemsPerCell</overlayType>
+                                    </li>
+                                </comps>
+                            </ThingDef>
+                        </value>
+                    </li>
+                    <!--Wooden Boxes-->
+                    <li Class="PatchOperationRemove">
+                        <xpath>/Defs/ThingDef[defName="VFEPD_BoxLarge" or defName="VFEPD_BoxSmall" or defName="VFEPD_PalletBoxes"]</xpath>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <DesignatorDropdownGroupDef>
+                                <defName>DZ_Storage_WoodenBoxes</defName>
+                            </DesignatorDropdownGroupDef>
+                        </value>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <ThingDef Name="DZ_VFEPD_BoxLarge" ParentName="LWM_Big_Shelf">
+                                <defName>DZ_VFEPD_BoxLarge</defName>
+                                <label>large wooden box</label>
+                                <description>A large wooden box that can hold various content.</description>
+                                <graphicData>	
+                                    <texPath>Things/Building/IndustrialProps/BoxLarge/BoxLarge</texPath>
+                                    <graphicClass>Graphic_Multi</graphicClass>
+                                    <drawSize>(1,1)</drawSize>
+                                    <shadowData>
+                                        <volume>(0.55, 0.30, 0.40)</volume>
+                                    </shadowData>
+                                </graphicData>
+                                <staticSunShadowHeight Inherit="false" />
+                                <defaultPlacingRot>South</defaultPlacingRot>
+                                <researchPrerequisites>
+                                    <li>IndustrialProps</li>
+                                </researchPrerequisites>
+                                <altitudeLayer>Building</altitudeLayer>
+                                <passability>PassThroughOnly</passability>
+                                <fillPercent>0.3</fillPercent>
+                                <statBases>
+                                    <MaxHitPoints>70</MaxHitPoints>
+                                    <WorkToBuild>150</WorkToBuild>
+                                    <Mass>15</Mass>
+                                    <Flammability>0.7</Flammability>
+                                </statBases>
+                                <size>(1,1)</size>
+                                <costList>
+                                    <WoodLog>40</WoodLog>
+                                </costList>
+                                <costStuffCount Inherit="false" />
+                                <stuffCategories Inherit="false" />
+                                <uiIconScale>1</uiIconScale>
+                                <designatorDropdown>DZ_Storage_WoodenBoxes</designatorDropdown>
+                                <building Inherit="false">
+                                    <ignoreStoredThingsBeauty>true</ignoreStoredThingsBeauty>
+                                    <preventDeteriorationOnTop>true</preventDeteriorationOnTop>
+                                    <defaultStorageSettings>
+                                        <priority>Important</priority>
+                                        <filter>
+                                        </filter>
+                                    </defaultStorageSettings>
+                                    <isInert>true</isInert>
+                                </building>
+                                <comps>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>3</maxNumberStacks>
+                                        <minTimeStoringTakes>50</minTimeStoringTakes>
+                                        <additionalTimeEachStack>20</additionalTimeEachStack>
+                                        <maxTotalMass>45</maxTotalMass><!--About a medium sized body-->
+                                        <additionalTimeEachDef>60</additionalTimeEachDef><!--Easier to use if it only stores the same item-->
+                                        <showContents>false</showContents>
+                                        <overlayType>None</overlayType>
+                                    </li>
+                                </comps>
+                            </ThingDef>
+
+                            <ThingDef ParentName="DZ_VFEPD_BoxLarge">
+                                <defName>DZ_VFEPD_BoxSmall</defName>
+                                <label>small wooden box</label>
+                                <description>A small wooden box that can hold various content.</description>
+                                <graphicData>	
+                                    <texPath>Things/Building/IndustrialProps/BoxSmall/BoxSmall</texPath>
+                                    <graphicClass>Graphic_Multi</graphicClass>
+                                    <drawSize>(1,1)</drawSize>
+                                    <shadowData>
+                                        <volume>(0.55, 0.30, 0.40)</volume>
+                                    </shadowData>
+                                </graphicData>
+                                <fillPercent>0.1</fillPercent>
+                                <statBases>
+                                    <MaxHitPoints>40</MaxHitPoints>
+                                    <WorkToBuild>100</WorkToBuild>
+                                    <Mass>8</Mass>
+                                    <Flammability>0.7</Flammability>
+                                </statBases>
+                                <size>(1,1)</size>
+                                <costList>
+                                    <WoodLog>25</WoodLog>
+                                </costList>
+                                <comps>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>2</maxNumberStacks>
+                                        <minTimeStoringTakes>50</minTimeStoringTakes>
+                                        <additionalTimeEachStack>20</additionalTimeEachStack>
+                                        <maxTotalMass>20</maxTotalMass><!--About a small sized body-->
+                                        <additionalTimeEachDef>60</additionalTimeEachDef><!--Easier to use if it only stores the same item-->
+                                        <showContents>false</showContents>
+                                        <overlayType>None</overlayType>
+                                    </li>
+                                </comps>
+                            </ThingDef>
+
+                            <ThingDef ParentName="DZ_VFEPD_BoxLarge">
+                                <defName>DZ_VFEPD_PalletBoxes</defName>
+                                <label>pallet with wooden boxes</label>
+                                <description>A large pallet with several wooden boxes.</description>
+                                <graphicData>	
+                                    <texPath>Things/Building/IndustrialProps/PalletBoxes</texPath>
+                                    <graphicClass>Graphic_Random</graphicClass>
+                                    <drawSize>(3,3)</drawSize>
+                                    <shadowData>
+                                        <volume>(0.55, 0.30, 0.40)</volume>
+                                    </shadowData>
+                                </graphicData>
+                                <fillPercent>0.4</fillPercent>
+                                <statBases>
+                                    <MaxHitPoints>150</MaxHitPoints>
+                                    <WorkToBuild>400</WorkToBuild>
+                                    <Mass>50</Mass>
+                                    <Flammability>0.7</Flammability>
+                                </statBases>
+                                <size>(2,2)</size>
+                                <costList>
+                                    <WoodLog>150</WoodLog>
+                                </costList>
+                                <comps>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>4</maxNumberStacks>
+                                        <minTimeStoringTakes>20</minTimeStoringTakes>
+                                        <additionalTimeEachStack>20</additionalTimeEachStack>
+                                        <maxMassOfStoredItem>50</maxMassOfStoredItem><!--About a medium sized body-->
+                                        <maxTotalMass>250</maxTotalMass>
+                                        <additionalTimeEachDef>20</additionalTimeEachDef>
+                                        <showContents>false</showContents>
+                                        <overlayType>None</overlayType>
+                                    </li>
+                                </comps>
+                            </ThingDef>
+                        </value>
+                    </li>
+                    <!--Carboard boxes. They will work mostly for small items. Basically a cheaper food basket-->
+                    <li Class="PatchOperationRemove">
+                        <xpath>/Defs/ThingDef[defName="VFEPD_CardboardBoxLarge" or defName="VFEPD_CardboardBoxSmall" or defName="VFEPD_PalletCardboard"]</xpath>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <DesignatorDropdownGroupDef>
+                                <defName>DZ_Storage_CardboardBoxes</defName>
+                            </DesignatorDropdownGroupDef>
+                        </value>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <ThingDef Name="DZ_VFEPD_CardboardBoxLarge" ParentName="LWM_Big_Shelf">
+                                <defName>DZ_VFEPD_CardboardBoxLarge</defName>
+                                <label>large cardboard box</label>
+                                <description>A large cardboard box. It can hold light contents. Cheaper than a wooden box.</description>
+                                <graphicData>	
+                                    <texPath>Things/Building/IndustrialProps/CardboardLarge/CardboardLarge</texPath>
+                                    <graphicClass>Graphic_Multi</graphicClass>
+                                    <drawSize>(1,1)</drawSize>
+                                    <shadowData>
+                                        <volume>(0.55, 0.30, 0.40)</volume>
+                                    </shadowData>
+                                </graphicData>
+                                <staticSunShadowHeight Inherit="false" />
+                                <defaultPlacingRot>South</defaultPlacingRot>
+                                <researchPrerequisites>
+                                    <li>IndustrialProps</li>
+                                </researchPrerequisites>
+                                <altitudeLayer>Building</altitudeLayer>
+                                <passability>PassThroughOnly</passability>
+                                <fillPercent>0.3</fillPercent>
+                                <statBases>
+                                    <MaxHitPoints>10</MaxHitPoints>
+                                    <WorkToBuild>50</WorkToBuild>
+                                    <Mass>1</Mass>
+                                    <Flammability>1</Flammability>
+                                </statBases>
+                                <size>(1,1)</size>
+                                <costList>
+                                    <WoodLog>20</WoodLog>
+                                </costList>
+                                <costStuffCount Inherit="false" />
+                                <stuffCategories Inherit="false" />
+                                <uiIconScale>1</uiIconScale>
+                                <designatorDropdown>DZ_Storage_CardboardBoxes</designatorDropdown>
+                                <building Inherit="false">
+                                    <ignoreStoredThingsBeauty>true</ignoreStoredThingsBeauty>
+                                    <preventDeteriorationOnTop>true</preventDeteriorationOnTop>
+                                    <fixedStorageSettings>
+                                        <priority>Important</priority>
+                                        <filter>
+                                            <categories>
+                                                <li>FoodRaw</li>
+                                                <li>PlantMatter</li>
+                                                <li>Drugs</li>
+                                                <li>Medicine</li>
+                                            </categories>
+                                        </filter>
+                                    </fixedStorageSettings>
+                                    <isInert>true</isInert>
+                                </building>
+                                <comps>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>4</maxNumberStacks>
+                                        <minTimeStoringTakes>20</minTimeStoringTakes>
+                                        <additionalTimeEachStack>20</additionalTimeEachStack>
+                                        <additionalTimeEachDef>30</additionalTimeEachDef><!--Easier to use if it only stores the same item-->
+                                        <showContents>false</showContents>
+                                        <overlayType>None</overlayType>
+                                    </li>
+                                </comps>
+                            </ThingDef>
+
+                            <ThingDef ParentName="DZ_VFEPD_CardboardBoxLarge">
+                                <defName>DZ_VFEPD_CardboardBoxSmall</defName>
+                                <label>small cardboard box</label>
+                                <description>A small cardboard box. It can hold light contents. Cheaper than a wooden box.</description>
+                                <graphicData>	
+                                    <texPath>Things/Building/IndustrialProps/CardboardSmall/CardboardSmall</texPath>
+                                    <graphicClass>Graphic_Multi</graphicClass>
+                                    <drawSize>(1,1)</drawSize>
+                                    <shadowData>
+                                        <volume>(0.55, 0.30, 0.40)</volume>
+                                    </shadowData>
+                                </graphicData>
+                                <fillPercent>0.1</fillPercent>
+                                <statBases>
+                                    <MaxHitPoints>10</MaxHitPoints>
+                                    <WorkToBuild>50</WorkToBuild>
+                                    <Mass>1</Mass>
+                                    <Flammability>1</Flammability>
+                                </statBases>
+                                <size>(1,1)</size>
+                                <costList>
+                                    <WoodLog>10</WoodLog>
+                                </costList>
+                                <comps>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>3</maxNumberStacks>
+                                        <minTimeStoringTakes>20</minTimeStoringTakes>
+                                        <additionalTimeEachStack>20</additionalTimeEachStack>
+                                        <additionalTimeEachDef>10</additionalTimeEachDef><!--Easier to use if it only stores the same item-->
+                                        <showContents>false</showContents>
+                                        <overlayType>None</overlayType>
+                                    </li>
+                                </comps>
+                            </ThingDef>
+
+                            <ThingDef ParentName="DZ_VFEPD_CardboardBoxLarge">
+                                <defName>VFEPD_PalletCardboard</defName>
+                                <label>pallet with cardboard boxes</label>
+                                <description>A large pallet with several cardboard boxes.</description>
+                                <graphicData>	
+                                    <texPath>Things/Building/IndustrialProps/PalletCardboard</texPath>
+                                    <graphicClass>Graphic_Random</graphicClass>
+                                    <drawSize>(3,3)</drawSize>
+                                    <shadowData>
+                                        <volume>(0.55, 0.30, 0.40)</volume>
+                                    </shadowData>
+                                </graphicData>
+                                <fillPercent>0.4</fillPercent>
+                                <statBases>
+                                    <MaxHitPoints>150</MaxHitPoints>
+                                    <WorkToBuild>300</WorkToBuild>
+                                    <Mass>20</Mass>
+                                    <Flammability>1</Flammability>
+                                </statBases>
+                                <size>(2,2)</size>
+                                <costList>
+                                    <WoodLog>75</WoodLog>
+                                </costList>
+                                <comps>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>5</maxNumberStacks>
+                                        <minTimeStoringTakes>20</minTimeStoringTakes>
+                                        <additionalTimeEachStack>20</additionalTimeEachStack>
+                                        <additionalTimeEachDef>20</additionalTimeEachDef>
+                                        <showContents>false</showContents>
+                                        <overlayType>None</overlayType>
+                                    </li>
+                                </comps>
+                            </ThingDef>
+                        </value>
+                    </li>
+                    <!--Pallet. It will be basically a 2x2 pallet. Could be made stuffable, but needs a better texture-->
+                    <li Class="PatchOperationRemove">
+                        <xpath>/Defs/ThingDef[defName="VFEPD_Pallet"]</xpath>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <ThingDef Name="DZ_VFEPD_Pallet" ParentName="LWM_Pallet">
+                                <defName>DZ_VFEPD_Pallet</defName>
+                                <label>large pallet</label>
+                                <description>A large pallet. Does not protect against the weather.  Sometimes difficult to manage, but useful nonetheless.</description>
+                                <graphicData>	
+                                <texPath>Things/Building/IndustrialProps/Pallet/Pallet</texPath>
+                                <graphicClass>Graphic_Single</graphicClass>
+                                    <drawSize>(2,2)</drawSize>
+                                    <shadowData>
+                                        <volume>(0.55, 0.30, 0.40)</volume>
+                                    </shadowData>
+                                </graphicData>
+                                <staticSunShadowHeight Inherit="false" />
+                                <defaultPlacingRot>South</defaultPlacingRot>
+                                <rotatable>False</rotatable>
+                                <researchPrerequisites>
+                                    <li>IndustrialProps</li>
+                                </researchPrerequisites>
+                                <altitudeLayer>Building</altitudeLayer>
+                                <passability>PassThroughOnly</passability>
+                                <fillPercent>0.1</fillPercent>
+                                <statBases>
+                                    <MaxHitPoints>50</MaxHitPoints>
+                                    <WorkToBuild>100</WorkToBuild>
+                                    <Mass>10</Mass>
+                                    <Flammability>0.7</Flammability>
+                                </statBases>
+                                <size>(2,2)</size>
+                                <costList>
+                                    <WoodLog>100</WoodLog>
+                                </costList>
+                                <costStuffCount Inherit="false" />
+                                <stuffCategories Inherit="false" />
+                                <uiIconScale>1</uiIconScale>
+                                <building Inherit="false">
+                                  <preventDeteriorationOnTop>false</preventDeteriorationOnTop>
+                                  <ignoreStoredThingsBeauty>false</ignoreStoredThingsBeauty>
+                                  <fixedStorageSettings>
+                                    <filter>
+                                      <categories>
+                                        <li>ResourcesRaw</li>
+                                        <li>Textiles</li>
+                                        <li>MortarShells</li>
+                                      </categories>
+                                      <disallowedCategories>
+                                        <li>PlantMatter</li>
+                                      </disallowedCategories>
+                                    </filter>
+                                  </fixedStorageSettings>
+                                </building>
+                                <comps>
+                                 <li Class="LWM.DeepStorage.Properties" >
+                                   <maxNumberStacks>4</maxNumberStacks>
+                                   <minTimeStoringTakes>200</minTimeStoringTakes>
+                                   <additionalTimeEachStack>50</additionalTimeEachStack>
+                                   <additionalTimeEachDef>20</additionalTimeEachDef>
+                                   <overlayType>SumOfAllItems</overlayType>
+                                 </li>
+                                </comps>
+                            </ThingDef>
+                        </value>
+                    </li>
+                    <!--Tall Cabinet. A better food basket. Stuffable instead of fixed materials-->
+                    <li Class="PatchOperationRemove">
+                        <xpath>/Defs/ThingDef[defName="VFEPD_SteelTallCabinet" or defName="VFEPD_PlasteelTallCabinet" or defName="VFEPD_SilverTallCabinet" or defName="VFEPD_WoodenTallCabinet"]</xpath>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <ThingDef Name="DZ_VFEPD_TallCabinet" ParentName="LWM_Food_Basket">
+                                <defName>DZ_VFEPD_TallCabinet</defName>
+                                <label>tall cabbinet</label>
+                                <description>A tall cabinet. Can hold food, drugs and medicine. Better than a food basket.</description>
+                                <graphicData>	
+                                <texPath>Things/Building/FurnitureProps/TallCabinet/TallCabinet</texPath>
+                                <graphicClass>Graphic_Multi</graphicClass>
+                                    <drawSize>(3.55,3.45)</drawSize>
+                                    <shadowData>
+                                        <volume>(0.30, 0.30, 0.40)</volume>
+                                    </shadowData>
+                                </graphicData>
+                                <staticSunShadowHeight Inherit="false" />
+                                <researchPrerequisites>
+                                    <li>FurnitureProps</li>
+                                </researchPrerequisites>
+                                <altitudeLayer>Building</altitudeLayer>
+                                <defaultPlacingRot>South</defaultPlacingRot>
+                                <castEdgeShadows>False</castEdgeShadows>
+                                <passability>PassThroughOnly</passability>
+                                <blockWind>true</blockWind>
+                                <fillPercent>0.1</fillPercent>
+                                <statBases>
+                                    <MaxHitPoints>20</MaxHitPoints>
+                                    <WorkToBuild>100</WorkToBuild>
+                                    <Mass>6</Mass>
+                                    <Flammability>1.0</Flammability>
+                                </statBases>
+                                <size>(1,1)</size>
+                                <stuffCategories>
+                                    <li>Metallic</li>
+                                    <li>Woody</li>
+                                    <li>Stony</li>
+                                </stuffCategories>
+                                <costStuffCount>80</costStuffCount>
+                                <uiIconScale>0.5</uiIconScale>
+                                <building Inherit="false">
+                                    <preventDeteriorationOnTop>true</preventDeteriorationOnTop>
+                                    <ignoreStoredThingsBeauty>true</ignoreStoredThingsBeauty>
+                                    <fixedStorageSettings>
+                                        <filter>
+                                            <categories>
+                                                <li>FoodRaw</li>
+                                                <li>PlantMatter</li>
+                                                <li>Drugs</li>
+                                                <li>Medicine</li>
+                                            </categories>
+                                            <thingDefs>
+                                                <li>Pemmican</li>
+                                                <li>Kibble</li>
+                                                <li>Neutroamine</li>
+                                            </thingDefs>
+                                        </filter>
+                                    </fixedStorageSettings>
+                                </building>
+                                <comps>
+                                 <li Class="LWM.DeepStorage.Properties" >
+                                    <maxNumberStacks>6</maxNumberStacks>
+                                    <minTimeStoringTakes>100</minTimeStoringTakes>
+                                    <additionalTimeEachStack>20</additionalTimeEachStack>
+                                    <additionalTimeEachDef>20</additionalTimeEachDef>
+                                    <showContents>false</showContents>
+                                    <overlayType>SumOfItemsPerCell</overlayType>
+                                 </li>
+                                </comps>
+                            </ThingDef>
+                        </value>
+                    </li>
+                    <!--Lockers, better clothing racks-->
+                    <li Class="PatchOperationRemove">
+                        <xpath>/Defs/ThingDef[defName="VFEPD_Lockers"]</xpath>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <ThingDef Name="DZ_VFEPD_Lockers" ParentName="LWM_Clothing_Rack">
+                                <defName>DZ_VFEPD_Lockers</defName>
+                                <label>lockers</label>
+                                <description>A metal locker unit, can store heavier clothing than a clothing rack.</description>
+                                <graphicData>	
+                                    <texPath>Things/Building/IndustrialProps/Lockers/Lockers</texPath>
+                                    <graphicClass>Graphic_Multi</graphicClass>
+                                    <drawSize>(2.5,2.5)</drawSize>
+                                    <shadowData>
+                                        <volume>(0.55, 0.30, 0.40)</volume>
+                                    </shadowData>
+                                </graphicData>
+                                <staticSunShadowHeight Inherit="false" />
+                                <researchPrerequisites>
+                                    <li>FurnitureProps</li>
+                                </researchPrerequisites>
+                                <altitudeLayer>Building</altitudeLayer>
+                                <defaultPlacingRot>South</defaultPlacingRot>
+                                <castEdgeShadows>False</castEdgeShadows>
+                                <passability>PassThroughOnly</passability>
+                                <blockWind>true</blockWind>
+                                <fillPercent>0.1</fillPercent>
+                                <statBases>
+                                    <MaxHitPoints>50</MaxHitPoints>
+                                    <WorkToBuild>100</WorkToBuild>
+                                    <Mass>10</Mass>
+                                    <Flammability>0.1</Flammability>
+                                </statBases>
+                                <size>(1,1)</size>
+                                <stuffCategories>
+                                    <li>Metallic</li>
+                                </stuffCategories>
+                                <costStuffCount>60</costStuffCount>
+                                <uiIconScale>0.5</uiIconScale>
+                                <building Inherit="false">
+                                    <preventDeteriorationOnTop>true</preventDeteriorationOnTop>
+                                    <ignoreStoredThingsBeauty>true</ignoreStoredThingsBeauty>
+                                    <fixedStorageSettings>
+                                        <filter>
+                                            <categories>
+                                                <li>Apparel</li>
+                                            </categories>
+                                        </filter>
+                                    </fixedStorageSettings>
+                                </building>
+                                <comps>
+                                 <li Class="LWM.DeepStorage.Properties" >
+                                    <maxNumberStacks>10</maxNumberStacks>
+                                    <minNumberStacks>4</minNumberStacks>
+                                    <maxTotalMass>10</maxTotalMass>
+                                    <minTimeStoringTakes>90</minTimeStoringTakes>
+                                    <additionalTimeEachStack>10</additionalTimeEachStack>
+                                    <showContents>false</showContents>
+                                    <overlayType>CountOfStacksPerCell</overlayType>
+                                </li>
+                                </comps>
+                            </ThingDef>
+                        </value>
+                    </li>
+                    <!--Warehouses shelfs. They will be a better pallet. Could be made stuffable, but needs better texture.
+                    The one with boxes will be able to store anything. Will be a similar to a tall shelf-->
+                    <li Class="PatchOperationRemove">
+                        <xpath>/Defs/ThingDef[defName="VFEPD_WarehouseShelfEmpty" or defName="VFEPD_WarehouseShelfBoxes"]</xpath>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <ThingDef Name="DZ_VFEPD_WarehouseShelfEmpty" ParentName="LWM_Pallet">
+                                <defName>DZ_VFEPD_WarehouseShelfEmpty</defName>
+                                <label>warehouse shelf</label>
+                                <description>An impassable warehouse shelf. Can store a lot of things, so long as they are not loose.</description>
+                                <graphicData>	
+                                    <texPath>Things/Building/FurnitureProps/WarehouseShelfEmpty/WarehouseShelfEmpty</texPath>
+                                    <graphicClass>Graphic_Multi</graphicClass>
+                                    <drawSize>(3,3)</drawSize>
+                                </graphicData>
+                                <staticSunShadowHeight Inherit="false" />
+                                <researchPrerequisites>
+                                    <li>IndustrialProps</li>
+                                </researchPrerequisites>
+                                <altitudeLayer>Building</altitudeLayer>
+                                <defaultPlacingRot>South</defaultPlacingRot>
+                                <castEdgeShadows>False</castEdgeShadows>
+                                <passability>PassThroughOnly</passability>
+                                <blockWind>true</blockWind>
+                                <fillPercent>0.3</fillPercent>
+                                <statBases>
+                                    <MaxHitPoints>100</MaxHitPoints>
+                                    <WorkToBuild>1500</WorkToBuild>
+                                    <Mass>30</Mass>
+                                    <Flammability>0.1</Flammability>
+                                </statBases>
+                                <size>(2,1)</size>
+                                <costList>
+                                    <Steel>120</Steel>
+                                </costList>
+                                <costStuffCount Inherit="false" />
+                                <stuffCategories Inherit="false" />
+                                <uiIconScale>1</uiIconScale>
+                                <building Inherit="false">
+                                    <preventDeteriorationOnTop>true</preventDeteriorationOnTop>
+                                    <ignoreStoredThingsBeauty>false</ignoreStoredThingsBeauty>
+                                    <fixedStorageSettings>
+                                        <filter>
+                                            <categories>
+                                                <li>ResourcesRaw</li>
+                                                <li>Textiles</li>
+                                                <li>MortarShells</li>
+                                                <li>Medicine</li>
+                                            </categories>
+                                            <thingDefs>
+                                                <li>ComponentIndustrial</li>
+                                                <li>ComponentSpacer</li>
+                                            </thingDefs>
+                                            <disallowedCategories>
+                                                <li>PlantMatter</li>
+                                            </disallowedCategories>
+                                        </filter>
+                                    </fixedStorageSettings>
+                                </building>
+                                <comps>
+                                 <li Class="LWM.DeepStorage.Properties" >
+                                    <maxNumberStacks>5</maxNumberStacks>
+                                    <minTimeStoringTakes>300</minTimeStoringTakes>
+                                    <additionalTimeEachStack>110</additionalTimeEachStack>
+                                    <additionalTimeEachDef>20</additionalTimeEachDef>
+                                    <overlayType>SumOfItemsPerCell</overlayType>
+                                 </li>
+                                </comps>
+                            </ThingDef>
+
+                            <ThingDef Name="DZ_VFEPD_WarehouseShelfBoxes" ParentName="LWM_VeryBigShelf">
+                                <defName>DZ_VFEPD_WarehouseShelfBoxes</defName>
+                                <label>warehouse shelf</label>
+                                <description>An impassable warehouse shelf. Can store a lot of things. It can take a while to take and store items from such a tall structure. Items here will not deteriorate, even if outside.</description>
+                                <graphicData>	
+                                    <texPath>Things/Building/FurnitureProps/WarehouseShelfBoxes/WarehouseShelfBoxes</texPath>
+                                    <graphicClass>Graphic_Multi</graphicClass>
+                                    <drawSize>(3,3)</drawSize>
+                                </graphicData>
+                                <staticSunShadowHeight Inherit="false" />
+                                <researchPrerequisites>
+                                    <li>IndustrialProps</li>
+                                </researchPrerequisites>
+                                <altitudeLayer>Building</altitudeLayer>
+                                <defaultPlacingRot>South</defaultPlacingRot>
+                                <castEdgeShadows>False</castEdgeShadows>
+                                <passability>PassThroughOnly</passability>
+                                <blockWind>true</blockWind>
+                                <fillPercent>0.3</fillPercent>
+                                <statBases>
+                                    <MaxHitPoints>120</MaxHitPoints>
+                                    <WorkToBuild>1500</WorkToBuild>
+                                    <Mass>35</Mass>
+                                    <Flammability>0.2</Flammability>
+                                </statBases>
+                                <size>(2,1)</size>
+                                <costList>
+                                    <Steel>120</Steel>
+                                    <WoodLog>20</WoodLog>
+                                </costList>
+                                <costStuffCount Inherit="false" />
+                                <stuffCategories Inherit="false" />
+                                <uiIconScale>1</uiIconScale>
+                                <building Inherit="false">
+                                    <preventDeteriorationOnTop>true</preventDeteriorationOnTop>
+                                    <ignoreStoredThingsBeauty>false</ignoreStoredThingsBeauty>
+                                    <fixedStorageSettings>
+                                        <filter>
+                                            <categories>
+                                                <li>ResourcesRaw</li>
+                                                <li>Textiles</li>
+                                                <li>MortarShells</li>
+                                                <li>Medicine</li>
+                                            </categories>
+                                            <thingDefs>
+                                                <li>ComponentIndustrial</li>
+                                                <li>ComponentSpacer</li>
+                                            </thingDefs>
+                                            <disallowedCategories>
+                                                <li>PlantMatter</li>
+                                            </disallowedCategories>
+                                        </filter>
+                                    </fixedStorageSettings>
+                                </building>
+                                <comps>
+                                 <li Class="LWM.DeepStorage.Properties" >
+                                    <maxNumberStacks>5</maxNumberStacks>
+                                    <minTimeStoringTakes>300</minTimeStoringTakes>
+                                    <additionalTimeEachStack>110</additionalTimeEachStack>
+                                    <additionalTimeEachDef>10</additionalTimeEachDef>
+                                    <maxMassOfStoredItem>90</maxMassOfStoredItem>
+                                    <maxTotalMass>320</maxTotalMass>
+                                    <showContents>false</showContents>
+                                    <overlayType>SumOfItemsPerCell</overlayType>
+                                 </li>
+                                </comps>
+                            </ThingDef>
+                        </value>
+                    </li>
+                    <!--Vending machines. Can store meals an drugs. I guess they can make sense for Hospitality's visitors, who can buy stuff from specific areas if allowed.-->
+                    <li Class="PatchOperationRemove">
+                        <xpath>/Defs/ThingDef[defName="VFEPD_SteelVendingMachine" or defName="VFEPD_PlasteelVendingMachine" or defName="VFEPD_SilverVendingMachine" or defName="VFEPD_WoodenVendingMachine"]</xpath>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <ThingDef Name="DZ_VFEPD_VendingMachine" ParentName="LWM_Food_Basket">
+                                <defName>DZ_VFEPD_VendingMachine</defName>
+                                <label>vending machine</label>
+                                <description>A vending machine. You can store food and drugs here. Your pawns refuse to pay for using it, though.</description>
+                                <graphicData>	
+                                    <texPath>Things/Building/FurnitureProps/VendingMachine/VendingMachine</texPath>
+                                    <graphicClass>Graphic_Multi</graphicClass>
+                                    <shaderType>CutoutComplex</shaderType>
+                                    <drawSize>(3.5,3.5)</drawSize>
+                                    <shadowData>
+                                        <volume>(0.30, 0.30, 0.40)</volume>
+                                    </shadowData>
+                                </graphicData>
+                                <staticSunShadowHeight Inherit="false" />
+                                <researchPrerequisites>
+                                    <li>FurnitureProps</li>
+                                </researchPrerequisites>
+                                <altitudeLayer>Building</altitudeLayer>
+                                <defaultPlacingRot>South</defaultPlacingRot>
+                                <castEdgeShadows>False</castEdgeShadows>
+                                <passability>PassThroughOnly</passability>
+                                <blockWind>true</blockWind>
+                                <fillPercent>0.5</fillPercent>
+                                <statBases>
+                                    <MaxHitPoints>50</MaxHitPoints>
+                                    <WorkToBuild>120</WorkToBuild>
+                                    <Mass>10</Mass>
+                                    <Flammability>0.1</Flammability>
+                                </statBases>
+                                <size>(1,1)</size>
+                                <stuffCategories Inherit="false">
+                                    <li>Metallic</li>
+                                </stuffCategories>
+                                <costStuffCount>50</costStuffCount>
+                                <uiIconScale>0.5</uiIconScale>
+                                <building Inherit="false">
+                                    <preventDeteriorationOnTop>true</preventDeteriorationOnTop>
+                                    <ignoreStoredThingsBeauty>true</ignoreStoredThingsBeauty>
+                                    <fixedStorageSettings>
+                                        <filter>
+                                            <categories>
+                                                <li>FoodMeals</li>
+                                                <li>Drugs</li>
+                                                <li>Medicine</li>
+                                            </categories>
+                                            <thingDefs>
+                                                <li>Pemmican</li>
+                                            </thingDefs>
+                                        </filter>
+                                    </fixedStorageSettings>
+                                </building>
+                                <comps>
+                                 <li Class="LWM.DeepStorage.Properties" >
+                                    <maxNumberStacks>10</maxNumberStacks>
+                                    <minTimeStoringTakes>25</minTimeStoringTakes>
+                                    <additionalTimeEachStack>5</additionalTimeEachStack>
+                                    <additionalTimeEachDef>2</additionalTimeEachDef>
+                                    <showContents>false</showContents>
+                                    <overlayType>SumOfAllItems</overlayType>
+                                 </li>
+                                </comps>
+                            </ThingDef>
+                        </value>
+                    </li>
+                    <!--Concrete bags. Renamed to storage bags. They can hold plant matter in great quantities.-->
+                    <li Class="PatchOperationRemove">
+                        <xpath>/Defs/ThingDef[defName="VFEPD_ConcreteBags"]</xpath>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <ThingDef Name="DZ_VFEPD_ConcreteBags" ParentName="LWM_Skip">
+                                <defName>DZ_VFEPD_ConcreteBags</defName>
+                                <label>storage bags</label>
+                                <description>A stack of storage bags. Can hold loose materials. Items stored here will not deteriorate.</description>
+                                <graphicData>	
+                                    <texPath>Things/Building/IndustrialProps/ConcreteBags/ConcreteBags</texPath>
+                                    <graphicClass>Graphic_Single</graphicClass>
+                                    <drawSize>(1,1)</drawSize>
+                                    <shadowData>
+                                        <volume>(0.55, 0.30, 0.40)</volume>
+                                    </shadowData>
+                                </graphicData>
+                                <staticSunShadowHeight Inherit="false" />
+                                <defaultPlacingRot Inherit="false" />
+                                <rotatable>false</rotatable>
+                                <researchPrerequisites>
+                                    <li>IndustrialProps</li>
+                                </researchPrerequisites>
+                                <altitudeLayer>Building</altitudeLayer>
+                                <passability>PassThroughOnly</passability>
+                                <fillPercent>0.3</fillPercent>
+                                <statBases>
+                                    <MaxHitPoints>20</MaxHitPoints>
+                                    <WorkToBuild>130</WorkToBuild>
+                                    <Mass>5</Mass>
+                                    <Flammability>0.2</Flammability>
+                                </statBases>
+                                <size>(1,1)</size>
+                                <costList>
+                                    <WoodLog>10</WoodLog>
+                                    <Cloth>60</Cloth>
+                                </costList>
+                                <costStuffCount Inherit="false" />
+                                <stuffCategories Inherit="false" />
+                                <uiIconScale>1</uiIconScale>
+                                <building Inherit="false">
+                                    <ignoreStoredThingsBeauty>false</ignoreStoredThingsBeauty>
+                                    <preventDeteriorationOnTop>false</preventDeteriorationOnTop>
+                                    <fixedStorageSettings>
+                                        <filter>
+                                            <categories>
+                                                <li>PlantMatter</li>
+                                            </categories>
+                                        </filter>
+                                    </fixedStorageSettings>
+                                    <defaultStorageSettings>
+                                        <priority>Important</priority>
+                                        <filter>
+                                        </filter>
+                                    </defaultStorageSettings>
+                                    <isInert>true</isInert>
+                                </building>
+                                <comps>
+                                    <li Class="LWM.DeepStorage.Properties">
+                                        <maxNumberStacks>8</maxNumberStacks>
+                                        <minTimeStoringTakes>150</minTimeStoringTakes>
+                                        <additionalTimeEachStack>10</additionalTimeEachStack>
+                                        <additionalTimeEachDef>50</additionalTimeEachDef>
+                                        <showContents>false</showContents>
+                                        <overlayType>SumOfItemsPerCell</overlayType>
+                                    </li>
+                                </comps>
+                            </ThingDef>
+                        </value>
+                    </li>
                 </operations>
             </match>
         </match>
@@ -883,6 +2172,150 @@
                             <texPath>Things/Building/MedievalProps/BucketWater/BucketWater</texPath>
                         </value>
                     </li>-->
+                    <!--Bucket Water as alternative for water tub -->
+                    <li Class="PatchOperationRemove">
+                        <xpath>/Defs/ThingDef[defName="VFEPD_BucketwithWater"]</xpath>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <ThingDef Name="DZ_VFEPD_BucketwithWater" ParentName="BasedHygieneMom">
+                                <defName>DZ_VFEPD_BucketwithWater</defName>
+                                <label>water bucket</label>
+                                <description>water bucket used for personal hygiene. Must be regularly refilled with fresh water. Can also be used for drinking if thirst is enabled.</description>
+                                <thingClass>DubsBadHygiene.Building_washbucket</thingClass>
+                                <graphicData>	
+                                    <texPath>Things/Building/MedievalProps/BucketWater/BucketWater</texPath>
+                                    <graphicClass>Graphic_Single</graphicClass>
+                                    <drawSize>(1,1)</drawSize>
+                                </graphicData>
+                                <staticSunShadowHeight Inherit="false" />
+                                <defaultPlacingRot Inherit="false" />
+                                <thingCategories>
+                                    <li>BuildingsHygiene</li>
+                                </thingCategories>
+                                <minifiedDef>MinifiedThing</minifiedDef>
+                                <rotatable>false</rotatable>
+                                <researchPrerequisites>
+                                    <li>MedievalProps</li>
+                                </researchPrerequisites>
+                                <altitudeLayer>Building</altitudeLayer>
+                                <passability>PassThroughOnly</passability>
+                                <statBases>
+                                    <MaxHitPoints>20</MaxHitPoints>
+                                    <WorkToBuild>130</WorkToBuild>
+                                    <Mass>5</Mass>
+                                    <Flammability>0.2</Flammability>
+                                </statBases>
+                                <tickerType>Rare</tickerType>
+                                <fillPercent>0.15</fillPercent>
+                                <size>(1,1)</size>
+                                <costList>
+                                    <WoodLog>10</WoodLog>
+                                </costList>
+                                <socialPropernessMatters>true</socialPropernessMatters>
+                                <costStuffCount Inherit="false" />
+                                <stuffCategories Inherit="false" />
+                                <uiIconScale>1</uiIconScale>
+                                <comps>
+                                    <li>
+                                        <compClass>CompColorable</compClass>
+                                    </li>
+                                    <li Class="CompProperties_Forbiddable"/>
+                                </comps>
+                            </ThingDef>
+                        </value>
+                    </li>
+                    <!--Water Tank as alternative for water butt -->
+                    <li Class="PatchOperationRemove">
+                        <xpath>/Defs/ThingDef[defName="VFEPD_WaterTank"]</xpath>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <ThingDef Name="DZ_VFEPD_WaterTank" ParentName="BasedWaterTower">
+                                <defName>DZ_VFEPD_WaterTank</defName>
+                                <label>water tank</label>
+                                <description>Stores water for use by plumbed fixtures. If the contained water becomes contaminated, the tank must be drained. Pawns can wash their hands and drink (if thirst is enabled) from this building.</description>
+                                <thingClass>DubsBadHygiene.Building_Butt</thingClass>
+                                <graphicData>	
+                                    <texPath>Things/Building/IndustrialProps/WaterTank/WaterTank</texPath>
+                                    <graphicClass>Graphic_Single</graphicClass>
+                                    <drawSize>(1,1)</drawSize>
+                                    <shadowData>
+                                    <volume>(0.55, 0.30, 0.40)</volume>
+                                    </shadowData>
+                                </graphicData>
+                                <staticSunShadowHeight Inherit="false" />
+                                <defaultPlacingRot Inherit="false" />
+                                <thingCategories>
+                                    <li>BuildingsHygiene</li>
+                                </thingCategories>
+                                <minifiedDef>MinifiedThing</minifiedDef>
+                                <rotatable>false</rotatable>
+                                <researchPrerequisites>
+                                    <li>IndustrialProps</li>
+                                </researchPrerequisites>
+                                <altitudeLayer>Building</altitudeLayer>
+                                <passability>PassThroughOnly</passability>
+                                <statBases>
+                                    <MaxHitPoints>20</MaxHitPoints>
+                                    <WorkToBuild>200</WorkToBuild>
+                                    <Mass>5</Mass>
+                                    <Flammability>0.2</Flammability>
+                                </statBases>
+                                <tickerType>Rare</tickerType>
+                                <fillPercent>0.15</fillPercent>
+                                <size>(1,1)</size>
+                                <costList>
+                                    <Steel>20</Steel>
+                                </costList>
+                                <socialPropernessMatters>true</socialPropernessMatters>
+                                <costStuffCount Inherit="false" />
+                                <stuffCategories Inherit="false" />
+                                <uiIconScale>1</uiIconScale>
+                                <comps>
+                                    <li>
+                                        <compClass>CompColorable</compClass>
+                                    </li>
+                                    <li Class="CompProperties_Forbiddable"/>
+                                </comps>
+                            </ThingDef>
+                        </value>
+                    </li>
+                    <!--Water Dispenser as an alternative to Fountains-->
+                    <li Class="PatchOperationRemove">
+                        <xpath>/Defs/ThingDef[defName="VFEPD_WaterDispenser"]</xpath>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <ThingDef Name="DZ_VFEPD_WaterDispenser" ParentName="DubsDirtyBasinBase">
+                                <defName>DZ_VFEPD_WaterDispenser</defName>
+                                <label>water dispenser</label>
+                                <description>A large, standing fresh water dispenser used for drinking.</description>
+                                <graphicData>	
+                                    <texPath>Things/Building/KitchenProps/WaterDispenser/WaterDispenser</texPath>
+                                    <graphicClass>Graphic_Multi</graphicClass>
+                                    <drawSize>(2.5,2.5)</drawSize>
+                                </graphicData>
+                                <staticSunShadowHeight Inherit="false" />
+                                <defaultPlacingRot Inherit="false" />
+                                <thingCategories Inherit="false">
+                                    <li>BuildingsHygiene</li>
+                                </thingCategories>
+                                <researchPrerequisites>
+                                    <li>KitchenProps</li>
+                                </researchPrerequisites>
+                                <fillPercent>0.15</fillPercent>
+                                <size>(1,1)</size>
+                                <costList>
+                                    <Steel>20</Steel>
+                                </costList>
+                                <uiIconScale>0.7</uiIconScale>
+                            </ThingDef>
+                        </value>
+                    </li>
                     <li Class="PatchOperationRemove">
                         <xpath>/Defs/ThingDef[defName="VFEPD_WashingMachine"]</xpath>
                     </li>
@@ -925,6 +2358,21 @@
                                 <li>PlantScraps</li>
                             </value>
                         </li>
+                        <!--Concrete bags / Storage bags-->
+                        <li Class="PatchOperationAdd">
+                            <xpath>/Defs/ThingDef[defName="DZ_VFEPD_ConcreteBags"]/building/fixedStorageSettings/filter</xpath>
+                            <value>
+                                <thingDefs>
+                                    <li>RawCompost</li>
+                                    <li>Fertilizer</li>
+                                    <li>PileofDirt</li>
+                                    <li>SandPile</li>
+                                    <li>RFFClay</li>
+                                    <li>RottedMush</li>
+                                    <li>CrushedRocks</li>
+                                </thingDefs>
+                            </value>
+                        </li>
                     </operations>
                 </match>
             </match>
@@ -944,11 +2392,86 @@
                 <mods>
                     <li>Rimatomics</li>
                 </mods>
-                <match Class="PatchOperationAdd">
-                    <xpath>/Defs/ThingDef[defName="DZ_VFEPD_BarrelGreen" or defName="DZ_VFEPD_PalletBarrelGreen"]/building/fixedStorageSettings/filter/thingDefs</xpath>
-                    <value>
-                        <li>NuclearWaste</li>
-                    </value>
+                <match Class="PatchOperationSequence">
+                    <success>Always</success>
+                    <operations>
+                        <li Class="PatchOperationAdd">
+                            <xpath>/Defs/ThingDef[defName="DZ_VFEPD_BarrelGreen" or defName="DZ_VFEPD_PalletBarrelGreen"]/building/fixedStorageSettings/filter/thingDefs</xpath>
+                            <value>
+                                <li>NuclearWaste</li>
+                            </value>
+                        </li>
+                        <!--Toxic waste barrel-->
+                        <li Class="PatchOperationRemove">
+                            <xpath>/Defs/ThingDef[defName="VFEPD_ToxicWasteBarrel"]</xpath>
+                        </li>
+                        <li Class="PatchOperationAdd">
+                            <xpath>/Defs</xpath>
+                            <value>
+                                <ThingDef Name="DZ_VFEPD_ToxicWasteBarrel" ParentName="LWM_Skip">
+                                    <defName>VFEPD_ToxicWasteBarrel</defName>
+                                    <label>toxic waste barrel</label>
+                                    <description>A small barrel of toxic waste.</description>
+                                    <graphicData>	
+                                    <texPath>Things/Building/PowerProps/ToxicWasteBarrel/ToxicWasteBarrel</texPath>
+                                        <graphicClass>Graphic_Single</graphicClass>
+                                        <drawSize>(1,1)</drawSize>
+                                        <shadowData>
+                                            <volume>(0.55, 0.30, 0.40)</volume>
+                                        </shadowData>
+                                    </graphicData>
+                                    <staticSunShadowHeight Inherit="false" />
+                                    <defaultPlacingRot Inherit="false" />
+                                    <rotatable>false</rotatable>
+                                    <researchPrerequisites>
+                                        <li>IndustrialProps</li>
+                                    </researchPrerequisites>
+                                    <altitudeLayer>Building</altitudeLayer>
+                                    <passability>PassThroughOnly</passability>
+                                    <fillPercent>0.3</fillPercent>
+                                    <statBases>
+                                        <MaxHitPoints>200</MaxHitPoints>
+                                        <WorkToBuild>130</WorkToBuild>
+                                        <Mass>50</Mass>
+                                        <Flammability>0.2</Flammability>
+                                    </statBases>
+                                    <size>(1,1)</size>
+                                    <costList>
+                                        <Steel>40</Steel>
+                                    </costList>
+                                    <costStuffCount Inherit="false" />
+                                    <stuffCategories Inherit="false" />
+                                    <uiIconScale>1</uiIconScale>
+                                    <building Inherit="false">
+                                        <ignoreStoredThingsBeauty>false</ignoreStoredThingsBeauty>
+                                        <preventDeteriorationOnTop>false</preventDeteriorationOnTop>
+                                        <fixedStorageSettings>
+                                            <filter>
+                                                <thingDefs>
+                                                    <li>NuclearWaste</li>
+                                                </thingDefs>
+                                            </filter>
+                                        </fixedStorageSettings>
+                                        <defaultStorageSettings>
+                                            <priority>Important</priority>
+                                            <filter>
+                                            </filter>
+                                        </defaultStorageSettings>
+                                        <isInert>true</isInert>
+                                    </building>
+                                    <comps>
+                                        <li Class="LWM.DeepStorage.Properties">
+                                            <maxNumberStacks>8</maxNumberStacks>
+                                            <minTimeStoringTakes>20</minTimeStoringTakes>
+                                            <additionalTimeEachStack>10</additionalTimeEachStack>
+                                            <showContents>false</showContents>
+                                            <overlayType>SumOfItemsPerCell</overlayType>
+                                        </li>
+                                    </comps>
+                                </ThingDef>
+                            </value>
+                        </li>
+                    </operations>
                 </match>
             </match>
         </match>
@@ -1115,36 +2638,7 @@
                         <li>VBE_Tequila</li>
                         <li>VBE_Vodka</li>
                         <li>VBE_Whiskey</li>
-                        <li>VBE_DoubleWhiskey</li>
                     </value>
-                </match>
-            </match>
-        </match>
-    </Operation>
-
-    <Operation Class="PatchOperationFindMod">
-        <mods>
-            <li>Vanilla Furniture Expanded - Props and Decor</li>
-        </mods>
-        <match Class="PatchOperationFindMod">
-            <mods>
-                <li>LWM's Deep Storage</li>
-            </mods>
-            <match Class="PatchOperationFindMod">
-                <mods>
-                    <li>Vanilla Brewing Expanded</li>
-                </mods>
-                <match Class="PatchOperationFindMod">
-                    <mods>
-                        <li>Vanilla Plants Expanded</li>
-                    </mods>
-                    <match Class="PatchOperationAdd">
-                        <xpath>/Defs/ThingDef[defName="DZ_VFEPD_WineRack"]/building/fixedStorageSettings/filter/thingDefs</xpath>
-                        <value>
-                            <li>VBE_UnfermentedCider</li>
-                            <li>VBE_Cider</li>
-                        </value>
-                    </match>
                 </match>
             </match>
         </match>
@@ -1173,7 +2667,7 @@
         </match>
     </Operation>
 
-    <!--Vanilla Factions Expanded - Vikings-->
+    <!--RimFridge-->
     <Operation Class="PatchOperationFindMod">
         <mods>
             <li>Vanilla Furniture Expanded - Props and Decor</li>
@@ -1182,16 +2676,74 @@
             <mods>
                 <li>LWM's Deep Storage</li>
             </mods>
-            <match Class="PatchOperationFindMod">
-                <mods>
-                    <li>Vanilla Factions Expanded - Vikings</li>
-                </mods>
-                <match Class="PatchOperationAdd">
-                    <xpath>/Defs/ThingDef[defName="DZ_VFEPD_WineRack"]/building/fixedStorageSettings/filter/thingDefs</xpath>
-                    <value>
-                        <li>VFEV_Mead</li>
-                    </value>
-                </match>
+            <match Class="PatchOperationSequence">
+                <success>Always</success>
+                <operations>
+                    <li Class="PatchOperationRemove">
+                        <xpath>/Defs/ThingDef[defName="VFEPD_Fridge"]</xpath>
+                    </li>
+                    <li Class="PatchOperationAdd">
+                        <xpath>/Defs</xpath>
+                        <value>
+                            <ThingDef Name="DZ_VFEPD_Fridge" ParentName="LWM_DeepRimFridge">
+                                <defName>DZ_VFEPD_Fridge</defName>
+                                <label>fridge</label>
+                                <description>A fridge cabinet. Can hold food and freeze it. Easier to build and use than a deep fridge.</description>
+                                <graphicData>
+                                    <texPath>Things/Building/KitchenProps/Fridge/Fridge</texPath>
+                                    <graphicClass>Graphic_Multi</graphicClass>
+                                    <drawSize>(3,3)</drawSize>
+                                </graphicData>
+                                <staticSunShadowHeight Inherit="false" />
+                                <researchPrerequisites>
+                                    <li>KitchenProps</li>
+                                </researchPrerequisites>
+                                <terrainAffordanceNeeded>Light</terrainAffordanceNeeded>
+                                <castEdgeShadows>False</castEdgeShadows>
+                                <blockWind>true</blockWind>
+                                <statBases>
+                                    <MaxHitPoints>150</MaxHitPoints>
+                                    <WorkToBuild>500</WorkToBuild>
+                                    <Mass>30</Mass>
+                                    <Flammability>1.0</Flammability>
+                                </statBases>
+                                <size>(1,1)</size>
+                                <costList Inherit="false">
+                                    <Steel>50</Steel>
+                                    <ComponentIndustrial>2</ComponentIndustrial>
+                                </costList>
+                                <uiIconScale>0.5</uiIconScale>
+                                <comps Inherit="false">
+                                    <li Class="CompProperties_Flickable"/>
+                                    <li Class="CompProperties_Breakdownable"/>
+                                    <li Class="RimFridge.CompProperties_Refrigerator"> 
+                                        <drinksBestCold>
+                                            <li>Beer</li>
+                                            <li>RC2_Ale</li>
+                                            <li>RC2_Cider</li>
+                                            <li>RC2_Grog</li>
+                                            <li>RC2_Stout</li>
+                                        </drinksBestCold>
+                                        <findAllRottableForFilters>true</findAllRottableForFilters>
+                                    </li>
+                                    <li Class="CompProperties_Power">
+                                        <compClass>CompPowerTrader</compClass>
+                                        <basePowerConsumption>120</basePowerConsumption>
+                                    </li>
+                                    <li Class='LWM.DeepStorage.Properties'>
+                                        <minNumberStacks>2</minNumberStacks>
+                                        <maxNumberStacks>4</maxNumberStacks>
+                                        <maxMassOfStoredItem>100</maxMassOfStoredItem>
+                                        <minTimeStoringTakes>25</minTimeStoringTakes>
+                                        <additionalTimeEachStack>10</additionalTimeEachStack>
+                                        <additionalTimeEachDef>10</additionalTimeEachDef>
+                                        <overlayType>SumOfAllItems</overlayType>
+                                    </li>
+                                </comps>
+                            </ThingDef>
+                        </value>
+                    </li>
+                </operations>
             </match>
         </match>
     </Operation>


### PR DESCRIPTION
Took me a bit longer than I thought. Here is a summary of the changes I did:

Vanilla storage

- Wooden Logs and Large Wooden Logs now are wood storage.
- Empty weapon rack, Swords weapon rack and Spear weapon rack are now weapons storage. The Swords and Spears one hide the contents. They are slightly beautiful.
- Empty armor stand and Full armor stand are now apparel storage (intended for armor). The full one hides the contents. They are slightly beautiful.
- Wooden chest and Large wooden chest are now general purpose storage.
- The wagon is now a general purpose storage. It hides the contents because of it's big footprint. The items would be on top of the handle if the contents were visible.
- Small wooden box, Large wooden box and Pallet with wooden boxes are now general purpose storage.
- Small cardboard box, Large cardboard box and Pallet with cardboard are now loose items storage like the granary. They are cheaper than the wooden boxes and hold one stack more, at the cost of variety.
- Large pallet is now a dump storage like the LMW's Deep Storage pallet. They will work as 2x2 Pallet.
- The Tall Cabinet is now stuffable. It can store food items like the granary. It is better in every way than the food basket.
- The Locker is now stuffable. It can store apparel. It can store heavier clothing than the clothing racks.
- Empty warehouse shelf is now a dump storage like the pallet. It is better than the pallet. The texture is not stuffable.
- Warehouse shelf with boxes is now a general purpose storage. It is better than the tall shelves.
- The vending machines can store foods and drugs. They are better used with Hospitality visitor when allowed to buy in an area where the vending machines are.
- Concrete bags are now plant matter. It's very efficient.

Dubs Bad Hygiene

- The water bucket is now an alternative to the water tub
- The water tank is now an alternative to the water butt
- The water dispenser is now an alternative to a fountain

Fertile fields

- Concrete bags can store loose things like dirt, sand and fertilizer.

Rimatomics

- The toxic waste barrel is now a nuclear waste storage. Efficient for it's simple purpose.

Rimfridge

- The fridge (from kitchen props) is now a food storage like the deep fridge. It is faster to make and easier to use than the deep fridge, but less power efficient.

