### PR TITLE
Update .Load2_DesignationCategory_Combined.xml

### DIFF
--- a/Patches/.Load2_DesignationCategory_Combined.xml
+++ b/Patches/.Load2_DesignationCategory_Combined.xml
@@ -207,6 +207,64 @@
     </Operation>
 
     <!--==========
+    Defenses Expanded
+    ==========-->
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Defenses Expanded</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<success>Always</success>
+			<operations>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="RazorWireObstacle" or defName="RazorWireBarrier" or defName="Gabion" or defName="HBarrier_Tan" or defName="HBarrier_Green" or defName="HBarrier_FP" or defName="HBarrier_FP_Green" or defName="TBarrier"]/designationCategory</xpath>
+					<value>
+						<designationCategory>Security</designationCategory>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="TrapMine_M14AP"]</xpath>
+					<value>
+						<designationCategory>Security</designationCategory>
+					</value>
+				</li>
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/DesignationCategoryDef[defName="DefensesExpanded_CustomCategory"]</xpath>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+
+    <!--==========
+    Path Avoid
+    ==========-->
+
+    <Operation Class="PatchOperationFindMod">
+        <mods>
+            <li>[KV] Path Avoid</li>
+        </mods>
+        <match Class="PatchOperationSequence">
+			<operations>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/DesignationCategoryDef[defName="Zone"]/specialDesignatorClasses</xpath>
+					<value>
+						<li>PathAvoid.Designator_PathAvoid_Prefer</li>
+						<li>PathAvoid.Designator_PathAvoid_Normal</li>
+						<li>PathAvoid.Designator_PathAvoid_Dislike</li>
+						<li>PathAvoid.Designator_PathAvoid_Hate</li>
+						<li>PathAvoid.Designator_PathAvoid_Strong</li>
+						<li>PathAvoid.Designator_MapSettings</li>
+					</value>
+				</li>
+                <li Class="PatchOperationRemove">
+                    <xpath>/Defs/DesignationCategoryDef[defName="Pathing"]</xpath>
+                </li>
+			</operations>
+        </match>
+    </Operation>
+
+    <!--==========
     Alpha Biomes
     ==========-->
 
@@ -1369,7 +1427,7 @@
                 <li>LWM's Deep Storage</li>
             </mods>
             <nomatch Class="PatchOperationReplace">
-                <xpath>/Defs/ThingDef[defName="DrugCabinet"]/designationCategory</xpath>
+                <xpath>/Defs/ThingDef[defName="DrugCabinet" or defName="DrugCabinetFridge"]/designationCategory</xpath>
                 <value>
                     <designationCategory>DZ_Storage</designationCategory>
                 </value>

--- a/Patches/.Load2_DesignationCategory_Combined.xml
+++ b/Patches/.Load2_DesignationCategory_Combined.xml
@@ -207,64 +207,6 @@
     </Operation>
 
     <!--==========
-    Defenses Expanded
-    ==========-->
-
-	<Operation Class="PatchOperationFindMod">
-		<mods>
-			<li>Defenses Expanded</li>
-		</mods>
-		<match Class="PatchOperationSequence">
-			<success>Always</success>
-			<operations>
-				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="RazorWireObstacle" or defName="RazorWireBarrier" or defName="Gabion" or defName="HBarrier_Tan" or defName="HBarrier_Green" or defName="HBarrier_FP" or defName="HBarrier_FP_Green" or defName="TBarrier"]/designationCategory</xpath>
-					<value>
-						<designationCategory>Security</designationCategory>
-					</value>
-				</li>
-				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="TrapMine_M14AP"]</xpath>
-					<value>
-						<designationCategory>Security</designationCategory>
-					</value>
-				</li>
-				<li Class="PatchOperationRemove">
-					<xpath>Defs/DesignationCategoryDef[defName="DefensesExpanded_CustomCategory"]</xpath>
-				</li>
-			</operations>
-		</match>
-	</Operation>
-
-    <!--==========
-    Path Avoid
-    ==========-->
-
-    <Operation Class="PatchOperationFindMod">
-        <mods>
-            <li>[KV] Path Avoid</li>
-        </mods>
-        <match Class="PatchOperationSequence">
-			<operations>
-				<li Class="PatchOperationAdd">
-					<xpath>/Defs/DesignationCategoryDef[defName="Zone"]/specialDesignatorClasses</xpath>
-					<value>
-						<li>PathAvoid.Designator_PathAvoid_Prefer</li>
-						<li>PathAvoid.Designator_PathAvoid_Normal</li>
-						<li>PathAvoid.Designator_PathAvoid_Dislike</li>
-						<li>PathAvoid.Designator_PathAvoid_Hate</li>
-						<li>PathAvoid.Designator_PathAvoid_Strong</li>
-						<li>PathAvoid.Designator_MapSettings</li>
-					</value>
-				</li>
-                <li Class="PatchOperationRemove">
-                    <xpath>/Defs/DesignationCategoryDef[defName="Pathing"]</xpath>
-                </li>
-			</operations>
-        </match>
-    </Operation>
-
-    <!--==========
     Alpha Biomes
     ==========-->
 
@@ -592,6 +534,33 @@
             </operations>
         </match>
     </Operation>
+
+    <!--==========
+    Defenses Expanded
+    ==========-->
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Defenses Expanded</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<success>Always</success>
+			<operations>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="RazorWireObstacle" or defName="RazorWireBarrier" or defName="Gabion" or defName="HBarrier_Tan" or defName="HBarrier_Green" or defName="HBarrier_FP" or defName="HBarrier_FP_Green" or defName="TBarrier"]/designationCategory</xpath>
+					<value>
+						<designationCategory>Security</designationCategory>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="TrapMine_M14AP"]</xpath>
+					<value>
+						<designationCategory>Security</designationCategory>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
 
     <!--==========
     Door Mat
@@ -1642,6 +1611,27 @@
                     </value>
                 </li>
             </operations>
+        </match>
+    </Operation>
+	
+    <!--==========
+    Path Avoid
+    ==========-->
+
+    <Operation Class="PatchOperationFindMod">
+        <mods>
+            <li>[KV] Path Avoid</li>
+        </mods>
+        <match Class="PatchOperationAdd">
+					<xpath>/Defs/DesignationCategoryDef[defName="Zone"]/specialDesignatorClasses</xpath>
+					<value>
+						<li>PathAvoid.Designator_PathAvoid_Prefer</li>
+						<li>PathAvoid.Designator_PathAvoid_Normal</li>
+						<li>PathAvoid.Designator_PathAvoid_Dislike</li>
+						<li>PathAvoid.Designator_PathAvoid_Hate</li>
+						<li>PathAvoid.Designator_PathAvoid_Strong</li>
+						<li>PathAvoid.Designator_MapSettings</li>
+					</value>
         </match>
     </Operation>
 


### PR DESCRIPTION
This includes the support for Defenses Expanded, Path Avoid, and the fix for the refrigerated drug cabinet from Medical Supplements that we talked about on Steam, sorry it took me so long to get the PR up.

EDIT: Also I updated it to the latest docworld codebase too, so it should just be a straight merge.