### PR TITLE
Fix PRF patch failing after 2.5.0 update Fix #87

### DIFF
--- a/Patches/.Load2_DesignationCategory_Combined.xml
+++ b/Patches/.Load2_DesignationCategory_Combined.xml
@@ -1651,8 +1651,8 @@
         <match Class="PatchOperationSequence">
             <success>Always</success>
             <operations>
-                <li Class="PatchOperationReplace">
-                    <xpath>/Defs/ThingDef[@Name="PRF_FloorSign"]/designationCategory</xpath>
+                <li Class="PatchOperationAdd">
+                    <xpath>/Defs/ThingDef[@Name="PRF_FloorIconBase"]</xpath>
                     <value>
                         <designationCategory>DZ_Lighting</designationCategory>
                     </value>


### PR DESCRIPTION
Fixes #87 

It was causing the entire patch op seq to fail because their name changed *and* they no longer directly specified a designation category (now inheriting it from PRF_BuildingBase).

Note that this _will_ break PRF 2.4.9, so you probably want to do some fancy defensive patching if you care about that.

As an aside, I spent 4 very painful hours debugging this. Can't thank you folks enough for putting up with this for long enough to make these fantastic mods happen. Hope this helps a little bit.